### PR TITLE
refactor: simplify photos component data flow

### DIFF
--- a/app/components/ImgBlurHash.vue
+++ b/app/components/ImgBlurHash.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { decode } from 'blurhash'
+import { usePhotoImage } from '~/composables/usePhotoImageLoadState'
 
 interface Props {
   blurhash?: string
@@ -18,17 +19,11 @@ const props = withDefaults(defineProps<Props>(), {
 const image = useTemplateRef<HTMLImageElement>('image')
 const visible = useElementVisibility(image)
 const placeholder = shallowRef<string>()
-const loaded = shallowRef(false)
+const imageLoad = usePhotoImage(() => props.src)
 
-watch(
-  () => props.src,
-  () => {
-    loaded.value = false
-  },
-)
-watch([visible, () => props.blurhash], ([isVisible, hash]) => {
+watch([visible, () => props.blurhash, imageLoad.status], ([isVisible, hash]) => {
   placeholder.value = undefined
-  if (!isVisible || !hash || loaded.value || image.value?.complete) return
+  if (!isVisible || !hash || imageLoad.isLoaded.value || image.value?.complete) return
   try {
     const width = 32
     const height = Math.max(1, Math.min(64, Math.round(width / props.aspectRatio)))
@@ -58,9 +53,10 @@ watch([visible, () => props.blurhash], ([isVisible, hash]) => {
     class="object-cover"
     :style="{
       aspectRatio,
-      backgroundImage: !loaded && placeholder ? `url(${placeholder})` : undefined,
+      backgroundImage: !imageLoad.isLoaded && placeholder ? `url(${placeholder})` : undefined,
       backgroundSize: 'cover',
     }"
-    @load="loaded = true"
+    @load="imageLoad.markLoaded"
+    @error="imageLoad.markError"
   />
 </template>

--- a/app/components/photos/PhotoCardMedia.vue
+++ b/app/components/photos/PhotoCardMedia.vue
@@ -64,10 +64,10 @@ function handleVideoLoadedMetadata(event: Event) {
       :aspect-ratio="photo.width / photo.height"
       class="photo-card-media__visual"
     />
-  </span>
-  <span v-if="isVideo" class="photo-card-media__badge" aria-hidden="true">
-    <i class="i-hugeicons:video-ai" />
-    {{ duration }}
+    <span v-if="isVideo" class="photo-card-media__badge" aria-hidden="true">
+      <i class="i-hugeicons:video-ai" />
+      {{ duration }}
+    </span>
   </span>
 </template>
 

--- a/app/components/photos/PhotoDetail.vue
+++ b/app/components/photos/PhotoDetail.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { play } from 'cuelume'
-import type { ComponentPublicInstance, CSSProperties } from 'vue'
-import type { Photo, PhotoPreviewVariant } from '~/types'
+import type { Photo, PhotoPreviewLoadingState, PhotoPreviewVariant } from '~/types'
+import { providePhotoImageLoadState } from '~/composables/usePhotoImageLoadState'
 import PhotoDetailCanvas from './PhotoDetailCanvas.vue'
 import PhotoDetailControls from './photo-detail-controls/PhotoDetailControls.vue'
+import PhotoDetailFilmstrip from './PhotoDetailFilmstrip.vue'
 import PhotoDetailMetadata from './photo-detail-metadata/PhotoDetailMetadata.vue'
 
 interface Props {
@@ -22,14 +23,21 @@ interface Emits {
 
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+providePhotoImageLoadState()
 const dialogRef = useTemplateRef<HTMLElement>('dialog')
-const thumbnailRefs: HTMLElement[] = []
 const displayedPhoto = shallowRef<Photo | null>(null)
 const previewVariant = shallowRef<PhotoPreviewVariant>('compressed')
+const activePreviewVariant = shallowRef<PhotoPreviewVariant>('thumbnail')
 const checkerboard = shallowRef(false)
 const zoomLabel = shallowRef('100%')
 const downloadLoading = shallowRef(false)
 const downloadProgress = shallowRef(0)
+const previewLoading = shallowRef<PhotoPreviewLoadingState>({
+  thumbnail: false,
+  compressed: false,
+  origin: false,
+  blurhash: false,
+})
 const canvas = useTemplateRef<InstanceType<typeof PhotoDetailCanvas>>('canvas')
 
 const currentIndex = computed(() => {
@@ -37,6 +45,9 @@ const currentIndex = computed(() => {
   return props.photos.findIndex((photo) => photo.id === props.photo?.id)
 })
 const detailPhoto = computed(() => displayedPhoto.value ?? props.photo)
+const downloadVariant = computed<PhotoPreviewVariant>(() =>
+  detailPhoto.value?.mediaType === 'image' ? activePreviewVariant.value : 'origin',
+)
 const {
   counts: reactionCounts,
   saving: reactionSaving,
@@ -57,11 +68,6 @@ watch(
 
     await nextTick()
     dialogRef.value?.focus({ preventScroll: true })
-    thumbnailRefs[index]?.scrollIntoView({
-      behavior: 'smooth',
-      block: 'nearest',
-      inline: 'center',
-    })
   },
   { flush: 'post' },
 )
@@ -70,6 +76,7 @@ watch(
   () => props.photo?.id,
   () => {
     previewVariant.value = 'compressed'
+    activePreviewVariant.value = 'thumbnail'
   },
 )
 
@@ -92,14 +99,6 @@ function handleKeydown(event: KeyboardEvent) {
   }
 }
 
-function thumbnailStyle(item: Photo): CSSProperties {
-  return { aspectRatio: `${item.width} / ${item.height}` }
-}
-
-function setThumbnailRef(el: Element | ComponentPublicInstance | null, index: number) {
-  if (el instanceof HTMLElement) thumbnailRefs[index] = el
-}
-
 function handleDisplayedChange(photo: Photo) {
   displayedPhoto.value = photo
 }
@@ -107,6 +106,10 @@ function handleDisplayedChange(photo: Photo) {
 function handleCanvasLoadingChange(loading: boolean, progress: number) {
   downloadLoading.value = loading
   downloadProgress.value = progress
+}
+
+function handleCanvasPreviewLoadingChange(loading: PhotoPreviewLoadingState) {
+  previewLoading.value = loading
 }
 
 function handleCanvasZoomChange(label: string) {
@@ -128,6 +131,10 @@ function resetZoom() {
 function handlePreviewChange(variant: PhotoPreviewVariant) {
   if (detailPhoto.value?.mediaType !== 'image') return
   previewVariant.value = variant
+}
+
+function handleActiveVariantChange(variant: PhotoPreviewVariant) {
+  activePreviewVariant.value = variant
 }
 
 function handleSwipe(direction: 'prev' | 'next') {
@@ -215,7 +222,9 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
                 :reaction-saving="reactionSaving"
                 :preview-variant="previewVariant"
                 @displayed-change="handleDisplayedChange"
+                @active-variant-change="handleActiveVariantChange"
                 @loading-change="handleCanvasLoadingChange"
+                @preview-loading-change="handleCanvasPreviewLoadingChange"
                 @react="react"
                 @swipe="handleSwipe"
                 @zoom-change="handleCanvasZoomChange"
@@ -245,6 +254,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
                 :reaction-saving="reactionSaving"
                 :download-loading="downloadLoading"
                 :download-progress="downloadProgress"
+                :download-variant="downloadVariant"
                 :zoom-label="zoomLabel"
                 @react="react"
                 @zoom-in="zoomIn"
@@ -257,28 +267,17 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
               v-if="detailPhoto"
               :photo="detailPhoto"
               :reaction-counts="reactionCounts"
-              :preview-variant="previewVariant"
+              :preview-variant="activePreviewVariant"
+              :preview-loading="previewLoading"
               @preview-change="handlePreviewChange"
             />
           </div>
 
-          <footer class="photo-dialog__filmstrip" aria-label="Photo navigation">
-            <button
-              v-for="(item, index) in photos"
-              :key="item.id"
-              :ref="(el) => setThumbnailRef(el, index)"
-              type="button"
-              :class="{ 'is-active': item.id === photo.id }"
-              :style="thumbnailStyle(item)"
-              :aria-label="`View ${item.filename || item.id}`"
-              :aria-current="item.id === photo.id ? 'true' : undefined"
-              data-cuelume-toggle="page"
-              @click="emit('select', item)"
-            >
-              <img :src="item.thumbnail" :alt="item.filename" loading="lazy" decoding="async" />
-              <i v-if="item.mediaType === 'video'" class="i-hugeicons:play" aria-hidden="true" />
-            </button>
-          </footer>
+          <PhotoDetailFilmstrip
+            :photos="photos"
+            :active-photo-id="photo.id"
+            @select="emit('select', $event)"
+          />
         </section>
       </div>
     </Transition>
@@ -451,85 +450,8 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
   grid-row: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: clamp(1.5rem, 2.5vw, 2.75rem) clamp(1rem, 2vw, 2rem);
+  padding: clamp(1.25rem, 2vw, 2rem) clamp(0.75rem, 1.5vw, 1.5rem);
   scrollbar-width: thin;
-}
-
-.photo-dialog__filmstrip {
-  display: flex;
-  align-items: center;
-  min-height: 5.25rem;
-  gap: clamp(0.45rem, 0.8vw, 0.8rem);
-  padding: 0.7rem clamp(1rem, 3vw, 3rem);
-  overflow-x: auto;
-  border-top: 1px dashed var(--dialog-line);
-  box-sizing: border-box;
-  scrollbar-width: none;
-}
-
-.photo-dialog__filmstrip::-webkit-scrollbar {
-  display: none;
-}
-
-.photo-dialog__filmstrip button {
-  position: relative;
-  flex: 0 0 auto;
-  height: 3.25rem;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  opacity: 0.34;
-  cursor: pointer;
-  filter: grayscale(1) contrast(1.03);
-  transform: translateY(0);
-  transition:
-    filter 320ms ease,
-    opacity 320ms ease,
-    transform 420ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.photo-dialog__filmstrip button::after {
-  position: absolute;
-  right: 0;
-  bottom: -0.48rem;
-  left: 0;
-  height: 1px;
-  background: var(--dialog-text);
-  content: '';
-  opacity: 0;
-  transform: scaleX(0);
-  transition:
-    opacity 220ms ease,
-    transform 420ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.photo-dialog__filmstrip button.is-active {
-  opacity: 1;
-  filter: grayscale(0) contrast(1);
-  transform: translateY(-0.2rem);
-}
-
-.photo-dialog__filmstrip button.is-active::after {
-  opacity: 0.82;
-  transform: scaleX(1);
-}
-
-.photo-dialog__filmstrip img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.photo-dialog__filmstrip button > i {
-  position: absolute;
-  inset: 50% auto auto 50%;
-  width: 1rem;
-  height: 1rem;
-  padding: 0.32rem;
-  border-radius: 50%;
-  color: white;
-  transform: translate(-50%, -50%);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -545,22 +467,14 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
   .photo-dialog__nav--next:hover {
     transform: translate(0.18rem, -50%);
   }
-
-  .photo-dialog__filmstrip button:hover {
-    opacity: 0.74;
-    filter: grayscale(0.2) contrast(1);
-    transform: translateY(-0.12rem);
-  }
 }
 
-.photo-dialog__close:active,
-.photo-dialog__filmstrip button:active {
+.photo-dialog__close:active {
   transform: scale(0.97);
 }
 
 .photo-dialog__close:focus-visible,
-.photo-dialog__nav:focus-visible,
-.photo-dialog__filmstrip button:focus-visible {
+.photo-dialog__nav:focus-visible {
   outline: 1px dashed var(--dialog-text);
   outline-offset: 0.35rem;
 }
@@ -643,21 +557,12 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
   .photo-dialog__details {
     grid-column: 1;
     grid-row: 3;
-    padding: 1rem 0.75rem;
+    padding: 0.75rem 0.625rem;
     border-top: 1px dashed var(--dialog-line);
     border-left: 0;
     position: relative;
     top: -1px;
     z-index: 10;
-  }
-
-  .photo-dialog__filmstrip {
-    min-height: 4.75rem;
-    padding-inline: 1rem;
-  }
-
-  .photo-dialog__filmstrip button {
-    height: 2.8rem;
   }
 
   .photo-dialog__nav {
@@ -671,9 +576,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
   .photo-dialog-enter-active .photo-detail-canvas,
   .photo-dialog-leave-active .photo-detail-canvas,
   .photo-dialog__close,
-  .photo-dialog__nav,
-  .photo-dialog__filmstrip button,
-  .photo-dialog__filmstrip button::after {
+  .photo-dialog__nav {
     transition-duration: 1ms;
   }
 }

--- a/app/components/photos/PhotoDetail.vue
+++ b/app/components/photos/PhotoDetail.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { play } from 'cuelume'
-import type { Photo, PhotoPreviewLoadingState, PhotoPreviewVariant } from '~/types'
+import type { Photo } from '~/types'
+import { providePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import { providePhotoImageLoadState } from '~/composables/usePhotoImageLoadState'
 import PhotoDetailCanvas from './PhotoDetailCanvas.vue'
 import PhotoDetailControls from './photo-detail-controls/PhotoDetailControls.vue'
@@ -23,48 +24,35 @@ interface Emits {
 
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+const detailContext = providePhotoDetailContext({
+  photo: () => props.photo,
+  photos: () => props.photos,
+  visible: () => props.visible,
+  onClose: () => emit('close'),
+  onPrevious: () => emit('prev'),
+  onNext: () => emit('next'),
+  onSelect: (photo) => emit('select', photo),
+})
+const {
+  photo: selectedPhoto,
+  photos,
+  detailPhoto,
+  currentIndex,
+  hasPrev,
+  hasNext,
+  visible,
+  actions,
+} = detailContext
 providePhotoImageLoadState()
 const dialogRef = useTemplateRef<HTMLElement>('dialog')
-const displayedPhoto = shallowRef<Photo | null>(null)
-const previewVariant = shallowRef<PhotoPreviewVariant>('compressed')
-const activePreviewVariant = shallowRef<PhotoPreviewVariant>('thumbnail')
-const checkerboard = shallowRef(false)
-const zoomLabel = shallowRef('100%')
-const downloadLoading = shallowRef(false)
-const downloadProgress = shallowRef(0)
-const previewLoading = shallowRef<PhotoPreviewLoadingState>({
-  thumbnail: false,
-  compressed: false,
-  origin: false,
-  blurhash: false,
-})
-const canvas = useTemplateRef<InstanceType<typeof PhotoDetailCanvas>>('canvas')
-
-const currentIndex = computed(() => {
-  if (!props.photo || !props.photos.length) return -1
-  return props.photos.findIndex((photo) => photo.id === props.photo?.id)
-})
-const detailPhoto = computed(() => displayedPhoto.value ?? props.photo)
-const downloadVariant = computed<PhotoPreviewVariant>(() =>
-  detailPhoto.value?.mediaType === 'image' ? activePreviewVariant.value : 'origin',
-)
-const {
-  counts: reactionCounts,
-  saving: reactionSaving,
-  error: reactionError,
-  react,
-} = usePhotoReactions(detailPhoto)
-const hasPrev = computed(() => currentIndex.value > 0)
-const hasNext = computed(() => currentIndex.value < props.photos.length - 1)
 
 watch(
-  [currentIndex, () => props.visible],
-  async ([index, visible], [, wasVisible]) => {
-    if (!visible || index < 0) {
-      displayedPhoto.value = null
+  [currentIndex, visible],
+  async ([index, isVisible]) => {
+    if (!isVisible || index < 0) {
+      actions.setDisplayedPhoto(null)
       return
     }
-    if (!wasVisible) displayedPhoto.value = props.photo
 
     await nextTick()
     dialogRef.value?.focus({ preventScroll: true })
@@ -72,85 +60,28 @@ watch(
   { flush: 'post' },
 )
 
-watch(
-  () => props.photo?.id,
-  () => {
-    previewVariant.value = 'compressed'
-    activePreviewVariant.value = 'thumbnail'
-  },
-)
-
 function handleKeydown(event: KeyboardEvent) {
-  if (!props.visible) return
+  if (!visible.value) return
 
   if (event.key === 'Escape') {
     play('droplet')
-    emit('close')
+    actions.close()
     return
   }
   if (event.key === 'ArrowLeft' && hasPrev.value) {
     play('page')
-    emit('prev')
+    actions.previous()
     return
   }
   if (event.key === 'ArrowRight' && hasNext.value) {
     play('page')
-    emit('next')
-  }
-}
-
-function handleDisplayedChange(photo: Photo) {
-  displayedPhoto.value = photo
-}
-
-function handleCanvasLoadingChange(loading: boolean, progress: number) {
-  downloadLoading.value = loading
-  downloadProgress.value = progress
-}
-
-function handleCanvasPreviewLoadingChange(loading: PhotoPreviewLoadingState) {
-  previewLoading.value = loading
-}
-
-function handleCanvasZoomChange(label: string) {
-  zoomLabel.value = label
-}
-
-function zoomIn() {
-  canvas.value?.zoomIn()
-}
-
-function zoomOut() {
-  canvas.value?.zoomOut()
-}
-
-function resetZoom() {
-  canvas.value?.resetCanvas()
-}
-
-function handlePreviewChange(variant: PhotoPreviewVariant) {
-  if (detailPhoto.value?.mediaType !== 'image') return
-  previewVariant.value = variant
-}
-
-function handleActiveVariantChange(variant: PhotoPreviewVariant) {
-  activePreviewVariant.value = variant
-}
-
-function handleSwipe(direction: 'prev' | 'next') {
-  if (direction === 'prev' && hasPrev.value) {
-    play('page')
-    emit('prev')
-  }
-  if (direction === 'next' && hasNext.value) {
-    play('page')
-    emit('next')
+    actions.next()
   }
 }
 
 function handleBackdropMouseDown() {
   play('droplet')
-  emit('close')
+  actions.close()
 }
 
 onMounted(() => document.addEventListener('keydown', handleKeydown))
@@ -161,7 +92,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
   <Teleport to="body">
     <Transition name="photo-dialog" :css="!transitioning">
       <div
-        v-if="visible && photo"
+        v-if="visible && selectedPhoto"
         class="photo-dialog__backdrop"
         @mousedown.self="handleBackdropMouseDown"
       >
@@ -192,7 +123,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
                 title="Close"
                 data-cuelume-hover="tick"
                 data-cuelume-toggle="droplet"
-                @click="emit('close')"
+                @click="actions.close"
               >
                 <i class="i-hugeicons:cancel-01" aria-hidden="true" />
               </button>
@@ -208,27 +139,12 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
                 aria-label="Previous photo"
                 data-cuelume-hover="tick"
                 data-cuelume-toggle="page"
-                @click="emit('prev')"
+                @click="actions.previous"
               >
                 <i class="i-hugeicons:arrow-left-01" aria-hidden="true" />
               </button>
 
-              <PhotoDetailCanvas
-                ref="canvas"
-                v-model:checkerboard="checkerboard"
-                :photo="photo"
-                :photos="photos"
-                :reaction-error="reactionError"
-                :reaction-saving="reactionSaving"
-                :preview-variant="previewVariant"
-                @displayed-change="handleDisplayedChange"
-                @active-variant-change="handleActiveVariantChange"
-                @loading-change="handleCanvasLoadingChange"
-                @preview-loading-change="handleCanvasPreviewLoadingChange"
-                @react="react"
-                @swipe="handleSwipe"
-                @zoom-change="handleCanvasZoomChange"
-              />
+              <PhotoDetailCanvas />
 
               <button
                 v-if="hasNext"
@@ -237,7 +153,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
                 aria-label="Next photo"
                 data-cuelume-hover="tick"
                 data-cuelume-toggle="page"
-                @click="emit('next')"
+                @click="actions.next"
               >
                 <i class="i-hugeicons:arrow-right-01" aria-hidden="true" />
               </button>
@@ -247,37 +163,13 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
               v-if="detailPhoto && detailPhoto.mediaType !== 'video'"
               class="photo-dialog__controls"
             >
-              <PhotoDetailControls
-                v-model:checkerboard="checkerboard"
-                :photo="detailPhoto"
-                :reaction-error="reactionError"
-                :reaction-saving="reactionSaving"
-                :download-loading="downloadLoading"
-                :download-progress="downloadProgress"
-                :download-variant="downloadVariant"
-                :zoom-label="zoomLabel"
-                @react="react"
-                @zoom-in="zoomIn"
-                @zoom-out="zoomOut"
-                @reset-zoom="resetZoom"
-              />
+              <PhotoDetailControls />
             </div>
 
-            <PhotoDetailMetadata
-              v-if="detailPhoto"
-              :photo="detailPhoto"
-              :reaction-counts="reactionCounts"
-              :preview-variant="activePreviewVariant"
-              :preview-loading="previewLoading"
-              @preview-change="handlePreviewChange"
-            />
+            <PhotoDetailMetadata v-if="detailPhoto" />
           </div>
 
-          <PhotoDetailFilmstrip
-            :photos="photos"
-            :active-photo-id="photo.id"
-            @select="emit('select', $event)"
-          />
+          <PhotoDetailFilmstrip />
         </section>
       </div>
     </Transition>

--- a/app/components/photos/PhotoDetailCanvas.vue
+++ b/app/components/photos/PhotoDetailCanvas.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import type { CSSProperties } from 'vue'
-import type { Photo, PhotoPreviewVariant, PhotoReactionType } from '~/types'
-import { isImagePreloaded, preloadImage } from '~/utils/preloadImage'
+import type {
+  Photo,
+  PhotoPreviewLoadingState,
+  PhotoPreviewVariant,
+  PhotoReactionType,
+} from '~/types'
+import { usePhotoImage, usePhotoImageLoadState } from '~/composables/usePhotoImageLoadState'
 import PhotoBlurhashPreview from './PhotoBlurhashPreview.vue'
 const PhotoVideoPlayer = defineAsyncComponent(() => import('./PhotoVideoPlayer.vue'))
 
@@ -29,6 +34,8 @@ interface Props {
 interface Emits {
   displayedChange: [photo: Photo]
   loadingChange: [loading: boolean, progress: number]
+  activeVariantChange: [variant: PhotoPreviewVariant]
+  previewLoadingChange: [loading: PhotoPreviewLoadingState]
   react: [reaction: PhotoReactionType]
   swipe: [direction: SwipeDirection]
   zoomChange: [label: string]
@@ -36,11 +43,15 @@ interface Emits {
 
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
+const imageLoadState = usePhotoImageLoadState()
 const preferredMotion = usePreferredReducedMotion()
 const displayedPhoto = shallowRef<Photo | null>(null)
 const displayedImageSrc = shallowRef('')
 const compressedImageSrc = shallowRef('')
 const isFullImageLoaded = shallowRef(false)
+const thumbnailImage = usePhotoImage(() => displayedPhoto.value?.thumbnail ?? '')
+const compressedImage = usePhotoImage(() => displayedPhoto.value?.compressed ?? '')
+const originImage = usePhotoImage(() => displayedPhoto.value?.origin ?? '')
 const previousPhoto = shallowRef<Photo | null>(null)
 const previousImageSrc = shallowRef('')
 const previousImageStyle = shallowRef<CSSProperties>()
@@ -79,20 +90,43 @@ const canvasClasses = computed(() => ({
   [`is-${direction.value}`]: true,
 }))
 const isDisplayedVideo = computed(() => displayedPhoto.value?.mediaType === 'video')
+const activePreviewVariant = computed<PhotoPreviewVariant>(() => {
+  if (
+    props.previewVariant === 'compressed' &&
+    !isDisplayedVideo.value &&
+    !thumbnailImage.isLoaded.value &&
+    !isFullImageLoaded.value
+  ) {
+    return 'blurhash'
+  }
+  if (props.previewVariant === 'compressed' && !isFullImageLoaded.value) return 'thumbnail'
+  return props.previewVariant
+})
 const isVariantPreviewVisible = computed(
-  () => !isDisplayedVideo.value && props.previewVariant !== 'compressed',
+  () => !isDisplayedVideo.value && activePreviewVariant.value !== 'compressed',
 )
+const previewLoading = computed<PhotoPreviewLoadingState>(() => ({
+  thumbnail: !isDisplayedVideo.value && thumbnailImage.isLoading.value,
+  compressed: !isDisplayedVideo.value && compressedImage.isLoading.value,
+  origin:
+    !isDisplayedVideo.value &&
+    props.previewVariant === 'origin' &&
+    !originImage.isLoaded.value &&
+    !originImage.hasError.value,
+  blurhash: false,
+}))
 const previewSrc = computed(() => {
   const photo = displayedPhoto.value
-  if (!photo || props.previewVariant === 'blurhash') return ''
-  if (props.previewVariant === 'thumbnail') return photo.thumbnail
-  if (props.previewVariant === 'origin') return photo.origin
+  const variant = activePreviewVariant.value
+  if (!photo || variant === 'blurhash') return ''
+  if (variant === 'thumbnail') return photo.thumbnail
+  if (variant === 'origin') return photo.origin
   return photo.compressed
 })
 const previewLabel = computed(() => {
-  if (props.previewVariant === 'thumbnail') return 'Thumbnail preview'
-  if (props.previewVariant === 'origin') return 'Original preview'
-  if (props.previewVariant === 'blurhash') return 'BlurHash preview'
+  if (activePreviewVariant.value === 'thumbnail') return 'Thumbnail preview'
+  if (activePreviewVariant.value === 'origin') return 'Original preview'
+  if (activePreviewVariant.value === 'blurhash') return 'BlurHash preview'
   return 'Compressed preview'
 })
 const currentImageStyle = computed<CSSProperties>(() => {
@@ -102,7 +136,7 @@ const currentImageStyle = computed<CSSProperties>(() => {
 const previewImageStyle = computed<CSSProperties>(() => {
   const photo = displayedPhoto.value
   if (!photo) return imageStyle.value
-  const maxWidth = props.previewVariant === 'thumbnail' ? 600 : Infinity
+  const maxWidth = activePreviewVariant.value === 'thumbnail' ? 600 : Infinity
   return getImageStyle(photo, maxWidth, imageStyle.value)
 })
 const swipeStart = shallowRef<SwipeStart | null>(null)
@@ -114,6 +148,18 @@ watch(
   { immediate: true },
 )
 watch(zoomLabel, (label) => emit('zoomChange', label), { immediate: true })
+watch(activePreviewVariant, (variant) => emit('activeVariantChange', variant), { immediate: true })
+watch(previewLoading, (loading) => emit('previewLoadingChange', loading), { immediate: true })
+
+watch(
+  [() => props.previewVariant, () => displayedPhoto.value?.id],
+  ([variant]) => {
+    const photo = displayedPhoto.value
+    if (variant !== 'origin' || !photo || photo.mediaType !== 'image') return
+    void originImage.preload({ expectedBytes: photo.originSize })
+  },
+  { immediate: true },
+)
 
 defineExpose({
   resetCanvas,
@@ -149,7 +195,7 @@ function preloadNeighbors(photo: Photo) {
 
   Promise.all(
     neighbors.map((neighbor) =>
-      preloadImage(neighbor.compressed, {
+      imageLoadState.preload(neighbor.compressed, {
         expectedBytes: neighbor.compressedSize,
       }),
     ),
@@ -225,6 +271,16 @@ function stopLoadingIndicator() {
   showLoading.value = false
 }
 
+function handleImageLoad(photoId: string, src: string) {
+  if (displayedPhoto.value?.id !== photoId) return
+  imageLoadState.markLoaded(src)
+}
+
+function handleImageError(photoId: string, src: string) {
+  if (displayedPhoto.value?.id !== photoId) return
+  imageLoadState.markError(src)
+}
+
 function scheduleTransitionCleanup(photoId: string) {
   if (transitionTimer) clearTimeout(transitionTimer)
 
@@ -242,8 +298,9 @@ async function displayPhoto(photo: Photo) {
   const currentRequest = ++requestId
   const outgoingPhoto = displayedPhoto.value
   if (outgoingPhoto?.id === photo.id) return
+  const hasCachedThumbnail = imageLoadState.isLoaded(photo.thumbnail)
   const compressedSrc = photo.compressed
-  const hasCachedCompressedImage = isImagePreloaded(compressedSrc)
+  const hasCachedCompressedImage = imageLoadState.isLoaded(compressedSrc)
 
   if (previousPhoto.value) {
     previousPhoto.value = null
@@ -272,14 +329,26 @@ async function displayPhoto(photo: Photo) {
   resetCanvas()
   emit('displayedChange', photo)
 
+  const thumbnailLoadingPromise =
+    photo.mediaType === 'image' && !hasCachedThumbnail
+      ? thumbnailImage.preload({
+          expectedBytes: photo.thumbnailSize,
+        })
+      : null
   const loadingPromise = hasCachedCompressedImage
     ? null
-    : preloadImage(compressedSrc, {
+    : compressedImage.preload({
         expectedBytes: photo.compressedSize,
         onProgress(progress) {
           if (currentRequest === requestId) loadProgress.value = progress.percentage
         },
       })
+  if (thumbnailLoadingPromise) {
+    void thumbnailLoadingPromise.then((loaded) => {
+      if (currentRequest !== requestId) return
+      if (loaded) imageLoadState.markLoaded(photo.thumbnail)
+    })
+  }
   preloadNeighbors(photo)
 
   await nextTick()
@@ -413,6 +482,8 @@ onBeforeUnmount(() => {
         decoding="async"
         draggable="false"
         :style="currentImageStyle"
+        @load="handleImageLoad(displayedPhoto.id, displayedImageSrc)"
+        @error="handleImageError(displayedPhoto.id, displayedImageSrc)"
       />
       <img
         v-if="compressedImageSrc && !isDisplayedVideo"
@@ -427,18 +498,20 @@ onBeforeUnmount(() => {
         decoding="async"
         draggable="false"
         :style="currentImageStyle"
+        @load="handleImageLoad(displayedPhoto.id, compressedImageSrc)"
+        @error="handleImageError(displayedPhoto.id, compressedImageSrc)"
       />
     </div>
 
     <div
       v-if="isVariantPreviewVisible && displayedPhoto"
-      :key="`${displayedPhoto.id}-${props.previewVariant}`"
+      :key="`${displayedPhoto.id}-${activePreviewVariant}`"
       class="photo-detail-canvas__preview"
       :aria-label="previewLabel"
       role="img"
     >
       <PhotoBlurhashPreview
-        v-if="props.previewVariant === 'blurhash'"
+        v-if="activePreviewVariant === 'blurhash'"
         :hash="displayedPhoto.blurhash"
         :width="displayedPhoto.width"
         :height="displayedPhoto.height"
@@ -452,6 +525,8 @@ onBeforeUnmount(() => {
         decoding="async"
         draggable="false"
         :style="previewImageStyle"
+        @load="handleImageLoad(displayedPhoto.id, previewSrc)"
+        @error="handleImageError(displayedPhoto.id, previewSrc)"
       />
     </div>
 

--- a/app/components/photos/PhotoDetailCanvas.vue
+++ b/app/components/photos/PhotoDetailCanvas.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
+import { play } from 'cuelume'
 import type { CSSProperties } from 'vue'
-import type {
-  Photo,
-  PhotoPreviewLoadingState,
-  PhotoPreviewVariant,
-  PhotoReactionType,
-} from '~/types'
+import type { Photo, PhotoPreviewLoadingState, PhotoPreviewVariant } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import { usePhotoImage, usePhotoImageLoadState } from '~/composables/usePhotoImageLoadState'
 import PhotoBlurhashPreview from './PhotoBlurhashPreview.vue'
 const PhotoVideoPlayer = defineAsyncComponent(() => import('./PhotoVideoPlayer.vue'))
 
 type SwitchDirection = 'prev' | 'next' | 'direct'
-type SwipeDirection = 'prev' | 'next'
 
 const COMPRESSED_IMAGE_MAX_WIDTH = 2560
 const SWIPE_MIN_DISTANCE = 48
@@ -23,26 +19,16 @@ interface SwipeStart {
   y: number
 }
 
-interface Props {
-  photo: Photo
-  photos: Photo[]
-  reactionError: string | null
-  reactionSaving: boolean
-  previewVariant: PhotoPreviewVariant
-}
-
-interface Emits {
-  displayedChange: [photo: Photo]
-  loadingChange: [loading: boolean, progress: number]
-  activeVariantChange: [variant: PhotoPreviewVariant]
-  previewLoadingChange: [loading: PhotoPreviewLoadingState]
-  react: [reaction: PhotoReactionType]
-  swipe: [direction: SwipeDirection]
-  zoomChange: [label: string]
-}
-
-const props = defineProps<Props>()
-const emit = defineEmits<Emits>()
+const detailContext = usePhotoDetailContext()
+const {
+  photo: selectedPhoto,
+  photos,
+  previewVariant,
+  checkerboard,
+  hasPrev,
+  hasNext,
+  actions,
+} = detailContext
 const imageLoadState = usePhotoImageLoadState()
 const preferredMotion = usePreferredReducedMotion()
 const displayedPhoto = shallowRef<Photo | null>(null)
@@ -60,7 +46,10 @@ const isAnimating = shallowRef(false)
 const showLoading = shallowRef(false)
 const loadProgress = shallowRef(0)
 const loadFailed = shallowRef(false)
-const useCheckerboard = defineModel<boolean>('checkerboard', { default: false })
+const useCheckerboard = computed({
+  get: () => checkerboard.value,
+  set: (value: boolean) => actions.setCheckerboard(value),
+})
 const {
   canvasRef,
   imageStyle,
@@ -92,15 +81,15 @@ const canvasClasses = computed(() => ({
 const isDisplayedVideo = computed(() => displayedPhoto.value?.mediaType === 'video')
 const activePreviewVariant = computed<PhotoPreviewVariant>(() => {
   if (
-    props.previewVariant === 'compressed' &&
+    previewVariant.value === 'compressed' &&
     !isDisplayedVideo.value &&
     !thumbnailImage.isLoaded.value &&
     !isFullImageLoaded.value
   ) {
     return 'blurhash'
   }
-  if (props.previewVariant === 'compressed' && !isFullImageLoaded.value) return 'thumbnail'
-  return props.previewVariant
+  if (previewVariant.value === 'compressed' && !isFullImageLoaded.value) return 'thumbnail'
+  return previewVariant.value
 })
 const isVariantPreviewVisible = computed(
   () => !isDisplayedVideo.value && activePreviewVariant.value !== 'compressed',
@@ -110,7 +99,7 @@ const previewLoading = computed<PhotoPreviewLoadingState>(() => ({
   compressed: !isDisplayedVideo.value && compressedImage.isLoading.value,
   origin:
     !isDisplayedVideo.value &&
-    props.previewVariant === 'origin' &&
+    previewVariant.value === 'origin' &&
     !originImage.isLoaded.value &&
     !originImage.hasError.value,
   blurhash: false,
@@ -144,15 +133,17 @@ const activeTouchPointers = new Set<number>()
 
 watch(
   [showLoading, loadProgress],
-  ([loading, progress]) => emit('loadingChange', loading, progress),
+  ([loading, progress]) => actions.setDownloadProgress(loading, progress),
   { immediate: true },
 )
-watch(zoomLabel, (label) => emit('zoomChange', label), { immediate: true })
-watch(activePreviewVariant, (variant) => emit('activeVariantChange', variant), { immediate: true })
-watch(previewLoading, (loading) => emit('previewLoadingChange', loading), { immediate: true })
+watch(zoomLabel, (label) => actions.setZoomLabel(label), { immediate: true })
+watch(activePreviewVariant, (variant) => actions.setActivePreviewVariant(variant), {
+  immediate: true,
+})
+watch(previewLoading, (loading) => actions.setPreviewLoading(loading), { immediate: true })
 
 watch(
-  [() => props.previewVariant, () => displayedPhoto.value?.id],
+  [previewVariant, () => displayedPhoto.value?.id],
   ([variant]) => {
     const photo = displayedPhoto.value
     if (variant !== 'origin' || !photo || photo.mediaType !== 'image') return
@@ -161,23 +152,19 @@ watch(
   { immediate: true },
 )
 
-defineExpose({
-  resetCanvas,
-  zoomIn,
-  zoomOut,
-})
+actions.registerCanvasControls({ reset: resetCanvas, zoomIn, zoomOut })
 
 watch(
-  () => props.photo,
+  selectedPhoto,
   (photo) => {
-    void displayPhoto(photo)
+    if (photo) void displayPhoto(photo)
   },
   { immediate: true },
 )
 
 function getPhotoIndex(photo: Photo | null): number {
   if (!photo) return -1
-  return props.photos.findIndex((item) => item.id === photo.id)
+  return photos.value.findIndex((item) => item.id === photo.id)
 }
 
 function getDirection(from: Photo | null, to: Photo): SwitchDirection {
@@ -191,7 +178,7 @@ function preloadNeighbors(photo: Photo) {
   const index = getPhotoIndex(photo)
   if (index < 0) return
 
-  const neighbors = [props.photos[index - 1], props.photos[index + 1]].filter((p) => !!p)
+  const neighbors = [photos.value[index - 1], photos.value[index + 1]].filter((p) => !!p)
 
   Promise.all(
     neighbors.map((neighbor) =>
@@ -258,7 +245,15 @@ function handleCanvasPointerEnd(event: PointerEvent) {
   const isHorizontalSwipe =
     Math.abs(deltaX) >= SWIPE_MIN_DISTANCE && Math.abs(deltaX) > Math.abs(deltaY) * SWIPE_AXIS_RATIO
 
-  if (isHorizontalSwipe) emit('swipe', deltaX > 0 ? 'prev' : 'next')
+  if (!isHorizontalSwipe) return
+
+  const direction = deltaX > 0 ? 'prev' : 'next'
+  const canNavigate = direction === 'prev' ? hasPrev.value : hasNext.value
+  if (!canNavigate) return
+
+  play('page')
+  if (direction === 'prev') actions.previous()
+  else actions.next()
 }
 
 function handleCanvasPointerCancel(event: PointerEvent) {
@@ -327,7 +322,7 @@ async function displayPhoto(photo: Photo) {
   loadFailed.value = false
   showLoading.value = !hasCachedCompressedImage
   resetCanvas()
-  emit('displayedChange', photo)
+  actions.setDisplayedPhoto(photo)
 
   const thumbnailLoadingPromise =
     photo.mediaType === 'image' && !hasCachedThumbnail
@@ -398,6 +393,7 @@ async function displayPhoto(photo: Photo) {
 }
 
 onBeforeUnmount(() => {
+  actions.registerCanvasControls(null)
   requestId += 1
   if (transitionTimer) clearTimeout(transitionTimer)
 })
@@ -461,14 +457,7 @@ onBeforeUnmount(() => {
       v-if="displayedPhoto"
       class="photo-detail-canvas__media photo-detail-canvas__media--current"
     >
-      <PhotoVideoPlayer
-        v-if="isDisplayedVideo"
-        :key="displayedPhoto.id"
-        :photo="displayedPhoto"
-        :reaction-error="reactionError"
-        :reaction-saving="reactionSaving"
-        @react="emit('react', $event)"
-      />
+      <PhotoVideoPlayer v-if="isDisplayedVideo" :key="displayedPhoto.id" />
       <img
         v-else
         ref="canvasImage"

--- a/app/components/photos/PhotoDetailFilmstrip.vue
+++ b/app/components/photos/PhotoDetailFilmstrip.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ComponentPublicInstance, CSSProperties } from 'vue'
 import type { Photo } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import { usePhotoImageLoadState } from '~/composables/usePhotoImageLoadState'
 import {
   getPhotoFilmstripCacheKey,
@@ -10,28 +11,19 @@ import {
 const PRELOAD_RADIUS = 2
 const SCROLL_SAVE_THROTTLE = 120
 
-interface Props {
-  photos: readonly Photo[]
-  activePhotoId: string
-}
-
-interface Emits {
-  select: [photo: Photo]
-}
-
-const props = defineProps<Props>()
-const emit = defineEmits<Emits>()
+const { photos, photo: selectedPhoto, actions } = usePhotoDetailContext()
 const filmstripRef = useTemplateRef<HTMLElement>('filmstrip')
 const thumbnailRefs = new Map<string, HTMLElement>()
 const imageLoadState = usePhotoImageLoadState()
 const scrollCache = usePhotoFilmstripScroll()
 const hasRestoredScroll = shallowRef(false)
 const collectionKey = computed(() =>
-  getPhotoFilmstripCacheKey(props.photos.map((photo) => photo.id)),
+  getPhotoFilmstripCacheKey(photos.value.map((photo) => photo.id)),
 )
 const activeIndex = computed(() =>
-  props.photos.findIndex((photo) => photo.id === props.activePhotoId),
+  photos.value.findIndex((photo) => photo.id === selectedPhoto.value?.id),
 )
+const activePhotoId = computed(() => selectedPhoto.value?.id ?? '')
 
 let scrollFrame: number | undefined
 let preloadTimer: ReturnType<typeof setTimeout> | undefined
@@ -46,7 +38,7 @@ function setThumbnailRef(element: Element | ComponentPublicInstance | null, phot
 }
 
 function scrollActivePhoto(behavior: ScrollBehavior = 'smooth') {
-  thumbnailRefs.get(props.activePhotoId)?.scrollIntoView({
+  thumbnailRefs.get(activePhotoId.value)?.scrollIntoView({
     behavior,
     block: 'nearest',
     inline: 'center',
@@ -100,9 +92,9 @@ function scheduleThumbnailPreload() {
     if (index < 0) return
 
     const start = Math.max(0, index - PRELOAD_RADIUS)
-    const end = Math.min(props.photos.length, index + PRELOAD_RADIUS + 1)
-    for (const photo of props.photos.slice(start, end)) {
-      if (photo.id === props.activePhotoId) continue
+    const end = Math.min(photos.value.length, index + PRELOAD_RADIUS + 1)
+    for (const photo of photos.value.slice(start, end)) {
+      if (photo.id === activePhotoId.value) continue
       if (imageLoadState.isLoaded(photo.thumbnail)) continue
       void imageLoadState.preload(photo.thumbnail, { expectedBytes: photo.thumbnailSize })
     }
@@ -119,7 +111,7 @@ watch(
 )
 
 watch(
-  () => props.activePhotoId,
+  activePhotoId,
   async (_photoId, previousPhotoId) => {
     scheduleThumbnailPreload()
     if (!hasRestoredScroll.value || previousPhotoId === undefined) return
@@ -169,7 +161,7 @@ onBeforeUnmount(() => {
       :aria-label="`View ${item.filename || item.id}`"
       :aria-current="item.id === activePhotoId ? 'true' : undefined"
       data-cuelume-toggle="page"
-      @click="emit('select', item)"
+      @click="actions.select(item)"
     >
       <ImgBlurHash
         :src="item.thumbnail"

--- a/app/components/photos/PhotoDetailFilmstrip.vue
+++ b/app/components/photos/PhotoDetailFilmstrip.vue
@@ -1,0 +1,304 @@
+<script setup lang="ts">
+import type { ComponentPublicInstance, CSSProperties } from 'vue'
+import type { Photo } from '~/types'
+import { usePhotoImageLoadState } from '~/composables/usePhotoImageLoadState'
+import {
+  getPhotoFilmstripCacheKey,
+  usePhotoFilmstripScroll,
+} from '~/composables/usePhotoFilmstripScroll'
+
+const PRELOAD_RADIUS = 2
+const SCROLL_SAVE_THROTTLE = 120
+
+interface Props {
+  photos: readonly Photo[]
+  activePhotoId: string
+}
+
+interface Emits {
+  select: [photo: Photo]
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+const filmstripRef = useTemplateRef<HTMLElement>('filmstrip')
+const thumbnailRefs = new Map<string, HTMLElement>()
+const imageLoadState = usePhotoImageLoadState()
+const scrollCache = usePhotoFilmstripScroll()
+const hasRestoredScroll = shallowRef(false)
+const collectionKey = computed(() =>
+  getPhotoFilmstripCacheKey(props.photos.map((photo) => photo.id)),
+)
+const activeIndex = computed(() =>
+  props.photos.findIndex((photo) => photo.id === props.activePhotoId),
+)
+
+let scrollFrame: number | undefined
+let preloadTimer: ReturnType<typeof setTimeout> | undefined
+
+function thumbnailStyle(photo: Photo): CSSProperties {
+  return { aspectRatio: `${photo.width} / ${photo.height}` }
+}
+
+function setThumbnailRef(element: Element | ComponentPublicInstance | null, photoId: string) {
+  if (element instanceof HTMLElement) thumbnailRefs.set(photoId, element)
+  else thumbnailRefs.delete(photoId)
+}
+
+function scrollActivePhoto(behavior: ScrollBehavior = 'smooth') {
+  thumbnailRefs.get(props.activePhotoId)?.scrollIntoView({
+    behavior,
+    block: 'nearest',
+    inline: 'center',
+  })
+}
+
+function clampScrollLeft(scrollLeft: number, element: HTMLElement) {
+  const maxScrollLeft = Math.max(0, element.scrollWidth - element.clientWidth)
+  return Math.min(Math.max(0, scrollLeft), maxScrollLeft)
+}
+
+async function restoreScroll() {
+  await nextTick()
+
+  const element = filmstripRef.value
+  if (!element) return
+
+  const cachedScrollLeft = scrollCache.read(collectionKey.value)
+  if (cachedScrollLeft === null) {
+    element.scrollLeft = 0
+    scrollActivePhoto('auto')
+  } else {
+    element.scrollLeft = clampScrollLeft(cachedScrollLeft, element)
+  }
+
+  hasRestoredScroll.value = true
+  scheduleThumbnailPreload()
+}
+
+function saveCurrentScroll() {
+  const element = filmstripRef.value
+  if (element) scrollCache.save(collectionKey.value, element.scrollLeft)
+}
+
+function handleScroll() {
+  if (scrollFrame !== undefined) return
+
+  scrollFrame = window.requestAnimationFrame(() => {
+    scrollFrame = undefined
+    saveCurrentScroll()
+  })
+}
+
+function scheduleThumbnailPreload() {
+  if (preloadTimer) clearTimeout(preloadTimer)
+
+  preloadTimer = setTimeout(() => {
+    preloadTimer = undefined
+
+    const index = activeIndex.value
+    if (index < 0) return
+
+    const start = Math.max(0, index - PRELOAD_RADIUS)
+    const end = Math.min(props.photos.length, index + PRELOAD_RADIUS + 1)
+    for (const photo of props.photos.slice(start, end)) {
+      if (photo.id === props.activePhotoId) continue
+      if (imageLoadState.isLoaded(photo.thumbnail)) continue
+      void imageLoadState.preload(photo.thumbnail, { expectedBytes: photo.thumbnailSize })
+    }
+  }, SCROLL_SAVE_THROTTLE)
+}
+
+watch(
+  collectionKey,
+  () => {
+    hasRestoredScroll.value = false
+    void restoreScroll()
+  },
+  { flush: 'post' },
+)
+
+watch(
+  () => props.activePhotoId,
+  async (_photoId, previousPhotoId) => {
+    scheduleThumbnailPreload()
+    if (!hasRestoredScroll.value || previousPhotoId === undefined) return
+
+    await nextTick()
+    scrollActivePhoto()
+  },
+  { flush: 'post' },
+)
+
+onMounted(() => {
+  void restoreScroll()
+})
+
+onBeforeUnmount(() => {
+  if (scrollFrame !== undefined) window.cancelAnimationFrame(scrollFrame)
+  if (preloadTimer) clearTimeout(preloadTimer)
+  saveCurrentScroll()
+  scrollCache.flush(collectionKey.value)
+})
+</script>
+
+<template>
+  <footer
+    ref="filmstrip"
+    class="photo-dialog__filmstrip"
+    aria-label="Photo navigation"
+    @scroll.passive="handleScroll"
+  >
+    <button
+      v-for="item in photos"
+      :key="item.id"
+      v-memo="[
+        item.id,
+        item.thumbnail,
+        item.blurhash,
+        item.mediaType,
+        item.width,
+        item.height,
+        item.id === activePhotoId,
+      ]"
+      :ref="(element) => setThumbnailRef(element, item.id)"
+      type="button"
+      class="photo-dialog__filmstrip-item"
+      :class="{ 'is-active': item.id === activePhotoId }"
+      :style="thumbnailStyle(item)"
+      :aria-label="`View ${item.filename || item.id}`"
+      :aria-current="item.id === activePhotoId ? 'true' : undefined"
+      data-cuelume-toggle="page"
+      @click="emit('select', item)"
+    >
+      <ImgBlurHash
+        :src="item.thumbnail"
+        :alt="item.filename"
+        :blurhash="item.blurhash"
+        :fetchpriority="item.id === activePhotoId ? 'high' : 'low'"
+        :loading="item.id === activePhotoId ? 'eager' : 'lazy'"
+        :aspect-ratio="item.width / item.height"
+        class="photo-dialog__filmstrip-image"
+        draggable="false"
+      />
+      <i v-if="item.mediaType === 'video'" class="i-hugeicons:play" aria-hidden="true" />
+    </button>
+  </footer>
+</template>
+
+<style scoped>
+.photo-dialog__filmstrip {
+  display: flex;
+  align-items: center;
+  min-height: 5.25rem;
+  gap: clamp(0.45rem, 0.8vw, 0.8rem);
+  padding: 0.7rem clamp(1rem, 3vw, 3rem);
+  overflow-x: auto;
+  border-top: 1px dashed var(--dialog-line);
+  box-sizing: border-box;
+  scrollbar-width: none;
+  contain: layout;
+  overscroll-behavior-x: contain;
+}
+
+.photo-dialog__filmstrip::-webkit-scrollbar {
+  display: none;
+}
+
+.photo-dialog__filmstrip-item {
+  position: relative;
+  flex: 0 0 auto;
+  height: 3.25rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  opacity: 0.34;
+  cursor: pointer;
+  filter: grayscale(1) contrast(1.03);
+  transform: translateY(0);
+  contain: layout;
+  transition:
+    filter 320ms ease,
+    opacity 320ms ease,
+    transform 420ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.photo-dialog__filmstrip-item::after {
+  position: absolute;
+  right: 0;
+  bottom: -0.48rem;
+  left: 0;
+  height: 1px;
+  background: var(--dialog-text);
+  content: '';
+  opacity: 0;
+  transform: scaleX(0);
+  transition:
+    opacity 220ms ease,
+    transform 420ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.photo-dialog__filmstrip-item.is-active {
+  opacity: 1;
+  filter: grayscale(0) contrast(1);
+  transform: translateY(-0.2rem);
+}
+
+.photo-dialog__filmstrip-item.is-active::after {
+  opacity: 0.82;
+  transform: scaleX(1);
+}
+
+.photo-dialog__filmstrip-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.photo-dialog__filmstrip-item > i {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: 1rem;
+  height: 1rem;
+  padding: 0.32rem;
+  border-radius: 50%;
+  color: white;
+  transform: translate(-50%, -50%);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .photo-dialog__filmstrip-item:hover {
+    opacity: 0.74;
+    filter: grayscale(0.2) contrast(1);
+    transform: translateY(-0.12rem);
+  }
+}
+
+.photo-dialog__filmstrip-item:active {
+  transform: scale(0.97);
+}
+
+.photo-dialog__filmstrip-item:focus-visible {
+  outline: 1px dashed var(--dialog-text);
+  outline-offset: 0.35rem;
+}
+
+@media (max-width: 767.9px) {
+  .photo-dialog__filmstrip {
+    min-height: 4.75rem;
+    padding-inline: 1rem;
+  }
+
+  .photo-dialog__filmstrip-item {
+    height: 2.8rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .photo-dialog__filmstrip-item,
+  .photo-dialog__filmstrip-item::after {
+    transition-duration: 1ms;
+  }
+}
+</style>

--- a/app/components/photos/PhotoVideoPlayer.vue
+++ b/app/components/photos/PhotoVideoPlayer.vue
@@ -1,22 +1,9 @@
 <script setup lang="ts">
-import type { Photo, PhotoReactionType } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import PhotoDetailControls from './photo-detail-controls/PhotoDetailControls.vue'
 
-interface Props {
-  photo: Photo
-  reactionError?: string | null
-  reactionSaving?: boolean
-}
-
-interface Emits {
-  react: [reaction: PhotoReactionType]
-}
-
-const props = withDefaults(defineProps<Props>(), {
-  reactionError: null,
-  reactionSaving: false,
-})
-const emit = defineEmits<Emits>()
+const { detailPhoto } = usePhotoDetailContext()
+const photo = computed(() => detailPhoto.value!)
 
 const video = useTemplateRef<HTMLVideoElement>('video')
 const ready = shallowRef(false)
@@ -67,9 +54,9 @@ watch(ready, async (isReady) => {
       slot="media"
       ref="video"
       class="photo-video-player__video"
-      :src="props.photo.origin"
-      :poster="props.photo.compressed"
-      :aria-label="props.photo.filename"
+      :src="photo.origin"
+      :poster="photo.compressed"
+      :aria-label="photo.filename"
       preload="metadata"
       autoplay
       playsinline
@@ -119,22 +106,16 @@ watch(ready, async (isReady) => {
         />
         <i slot="exit" class="photo-video-player__icon i-hugeicons:shrink" aria-hidden="true" />
       </media-fullscreen-button>
-      <PhotoDetailControls
-        variant="media"
-        :photo="props.photo"
-        :reaction-error="props.reactionError"
-        :reaction-saving="props.reactionSaving"
-        @react="emit('react', $event)"
-      />
+      <PhotoDetailControls variant="media" />
     </media-control-bar>
   </media-controller>
   <video
     v-else-if="loadFailed"
     ref="video"
     class="photo-video-player photo-video-player__video"
-    :src="props.photo.origin"
-    :poster="props.photo.compressed"
-    :aria-label="props.photo.filename"
+    :src="photo.origin"
+    :poster="photo.compressed"
+    :aria-label="photo.filename"
     preload="metadata"
     autoplay
     playsinline
@@ -142,7 +123,7 @@ watch(ready, async (isReady) => {
     @canplay="attemptAutoplay"
   />
   <div v-else class="photo-video-player photo-video-player--loading">
-    <img :src="props.photo.compressed" alt="" />
+    <img :src="photo.compressed" alt="" />
     <i class="i-hugeicons:loading-03" aria-hidden="true" />
   </div>
 </template>

--- a/app/components/photos/Photos.vue
+++ b/app/components/photos/Photos.vue
@@ -3,6 +3,7 @@ import type { Photo } from '~/types'
 import { VirtualWaterfall } from '@lhlyu/vue-virtual-waterfall'
 import PhotoEmptyState from '~/components/photos/PhotoEmptyState.vue'
 import PhotoCardMedia from '~/components/photos/PhotoCardMedia.vue'
+import PhotoHoverInfo from '~/components/photos/PhotoHoverInfo.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -28,7 +29,7 @@ const {
   handleScroll,
   calcItemHeight,
   refreshPhotos,
-} = usePhotos(props.photos)
+} = usePhotos(() => props.photos)
 
 function openPreview(photo: Photo, event: MouseEvent) {
   emit('open', photo, event.currentTarget as HTMLElement)
@@ -85,11 +86,11 @@ function openPreview(photo: Photo, event: MouseEvent) {
           >
             <PhotoCardMedia
               :photo="item"
-              :loading="item.id === photos[0]?.id ? 'eager' : 'lazy'"
+              :loading="item.id === allPhotos[0]?.id ? 'eager' : 'lazy'"
               class="photo-card__image"
               :style="{ '--media-aspect-ratio': `${item.width} / ${item.height}` }"
             />
-            <PhotosPhotoHoverInfo :photo="item" />
+            <PhotoHoverInfo :photo="item" />
           </button>
         </template>
       </VirtualWaterfall>

--- a/app/components/photos/photo-detail-controls/PhotoDetailBackgroundControl.vue
+++ b/app/components/photos/photo-detail-controls/PhotoDetailBackgroundControl.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import PhotoDetailControlButton from './PhotoDetailControlButton.vue'
 
-const checkerboard = defineModel<boolean>({ required: true })
+const { checkerboard, actions } = usePhotoDetailContext()
 const label = computed(() =>
   checkerboard.value ? 'Use blurred image background' : 'Use transparency checkerboard background',
 )
@@ -13,6 +14,6 @@ const icon = computed(() => (checkerboard.value ? 'i-hugeicons:blur' : 'i-hugeic
     :label="label"
     :icon="icon"
     :pressed="checkerboard"
-    @click="checkerboard = !checkerboard"
+    @click="actions.setCheckerboard(!checkerboard)"
   />
 </template>

--- a/app/components/photos/photo-detail-controls/PhotoDetailControls.vue
+++ b/app/components/photos/photo-detail-controls/PhotoDetailControls.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Photo, PhotoReactionType } from '~/types'
+import type { Photo, PhotoPreviewVariant, PhotoReactionType } from '~/types'
 import PhotoDetailBackgroundControl from './PhotoDetailBackgroundControl.vue'
 import PhotoDetailDownloadControl from './PhotoDetailDownloadControl.vue'
 import PhotoDetailReactionControl from './PhotoDetailReactionControl.vue'
@@ -14,6 +14,7 @@ interface Props {
   reactionDisabled?: boolean
   downloadLoading?: boolean
   downloadProgress?: number
+  downloadVariant?: PhotoPreviewVariant
   zoomLabel?: string
 }
 
@@ -31,6 +32,7 @@ const props = withDefaults(defineProps<Props>(), {
   reactionDisabled: false,
   downloadLoading: false,
   downloadProgress: 0,
+  downloadVariant: 'origin',
   zoomLabel: '100%',
 })
 const emit = defineEmits<Emits>()
@@ -74,6 +76,7 @@ const controlsClasses = computed(() => [
     <div class="photo-detail-controls__item">
       <PhotoDetailDownloadControl
         :photo="props.photo"
+        :variant="props.downloadVariant"
         :loading="props.downloadLoading"
         :progress="props.downloadProgress"
       />

--- a/app/components/photos/photo-detail-controls/PhotoDetailControls.vue
+++ b/app/components/photos/photo-detail-controls/PhotoDetailControls.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Photo, PhotoPreviewVariant, PhotoReactionType } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import PhotoDetailBackgroundControl from './PhotoDetailBackgroundControl.vue'
 import PhotoDetailDownloadControl from './PhotoDetailDownloadControl.vue'
 import PhotoDetailReactionControl from './PhotoDetailReactionControl.vue'
@@ -7,37 +7,13 @@ import PhotoDetailShareControl from './PhotoDetailShareControl.vue'
 import PhotoDetailZoomControls from './PhotoDetailZoomControls.vue'
 
 interface Props {
-  photo: Photo
   variant?: 'dialog' | 'media'
-  reactionError?: string | null
-  reactionSaving?: boolean
-  reactionDisabled?: boolean
-  downloadLoading?: boolean
-  downloadProgress?: number
-  downloadVariant?: PhotoPreviewVariant
-  zoomLabel?: string
-}
-
-interface Emits {
-  react: [reaction: PhotoReactionType]
-  zoomIn: []
-  zoomOut: []
-  resetZoom: []
 }
 
 const props = withDefaults(defineProps<Props>(), {
   variant: 'dialog',
-  reactionError: null,
-  reactionSaving: false,
-  reactionDisabled: false,
-  downloadLoading: false,
-  downloadProgress: 0,
-  downloadVariant: 'origin',
-  zoomLabel: '100%',
 })
-const emit = defineEmits<Emits>()
-const checkerboard = defineModel<boolean>('checkerboard', { default: false })
-const isVideo = computed(() => props.photo.mediaType === 'video')
+const { isVideo } = usePhotoDetailContext()
 const controlsClasses = computed(() => [
   'photo-detail-controls',
   `photo-detail-controls--${props.variant}`,
@@ -47,39 +23,23 @@ const controlsClasses = computed(() => [
 <template>
   <div :class="controlsClasses" role="group" aria-label="Media actions" @pointerdown.stop>
     <div class="photo-detail-controls__item">
-      <PhotoDetailReactionControl
-        :photo="props.photo"
-        :disabled="props.reactionDisabled"
-        :busy="props.reactionSaving"
-        :error="props.reactionError"
-        @react="emit('react', $event)"
-      />
+      <PhotoDetailReactionControl />
     </div>
 
     <div v-if="!isVideo" class="photo-detail-controls__item">
-      <PhotoDetailBackgroundControl v-model="checkerboard" />
+      <PhotoDetailBackgroundControl />
     </div>
 
     <div v-if="!isVideo" class="photo-detail-controls__item">
-      <PhotoDetailZoomControls
-        :zoom-label="props.zoomLabel"
-        @zoom-in="emit('zoomIn')"
-        @zoom-out="emit('zoomOut')"
-        @reset="emit('resetZoom')"
-      />
+      <PhotoDetailZoomControls />
     </div>
 
     <div class="photo-detail-controls__item">
-      <PhotoDetailShareControl :photo="props.photo" />
+      <PhotoDetailShareControl />
     </div>
 
     <div class="photo-detail-controls__item">
-      <PhotoDetailDownloadControl
-        :photo="props.photo"
-        :variant="props.downloadVariant"
-        :loading="props.downloadLoading"
-        :progress="props.downloadProgress"
-      />
+      <PhotoDetailDownloadControl />
     </div>
   </div>
 </template>

--- a/app/components/photos/photo-detail-controls/PhotoDetailDownloadControl.vue
+++ b/app/components/photos/photo-detail-controls/PhotoDetailDownloadControl.vue
@@ -1,26 +1,47 @@
 <script setup lang="ts">
-import type { Photo } from '~/types'
+import type { Photo, PhotoPreviewVariant } from '~/types'
+import { getPhotoDownloadFilename, getPhotoDownloadUrl } from '~/utils/photoDownload'
 import PhotoDetailControlButton from './PhotoDetailControlButton.vue'
 
 const props = withDefaults(
   defineProps<{
     photo: Photo
+    variant?: PhotoPreviewVariant
     loading?: boolean
     progress?: number
   }>(),
   {
+    variant: 'origin',
     loading: false,
     progress: 0,
   },
 )
 
 const mediaLabel = computed(() => (props.photo.mediaType === 'video' ? 'video' : 'image'))
-const label = computed(() =>
-  props.loading
-    ? `Loading compressed ${mediaLabel.value}`
-    : `Download original ${mediaLabel.value}`,
+const downloadVariant = computed<PhotoPreviewVariant>(() =>
+  props.photo.mediaType === 'image' ? props.variant : 'origin',
 )
-const href = computed(() => (props.loading ? undefined : `/api/photos/${props.photo.id}/download`))
+const isLoading = computed(() => props.loading && downloadVariant.value === 'compressed')
+const variantLabel = computed(() => {
+  if (downloadVariant.value === 'origin') return 'original'
+  if (downloadVariant.value === 'blurhash') return 'BlurHash'
+  return downloadVariant.value
+})
+const label = computed(() =>
+  isLoading.value
+    ? `Loading compressed ${mediaLabel.value}`
+    : downloadVariant.value === 'blurhash'
+      ? 'Download BlurHash'
+      : `Download ${variantLabel.value} ${mediaLabel.value}`,
+)
+const href = computed(() =>
+  isLoading.value
+    ? undefined
+    : getPhotoDownloadUrl(props.photo.id, downloadVariant.value, props.photo.blurhash),
+)
+const filename = computed(() =>
+  getPhotoDownloadFilename(props.photo.filename, downloadVariant.value),
+)
 </script>
 
 <template>
@@ -28,8 +49,8 @@ const href = computed(() => (props.loading ? undefined : `/api/photos/${props.ph
     :label="label"
     icon="i-hugeicons:download-04"
     :href="href"
-    :download="props.photo.filename"
-    :loading="props.loading"
+    :download="filename"
+    :loading="isLoading"
     :progress="props.progress"
   />
 </template>

--- a/app/components/photos/photo-detail-controls/PhotoDetailDownloadControl.vue
+++ b/app/components/photos/photo-detail-controls/PhotoDetailDownloadControl.vue
@@ -1,27 +1,18 @@
 <script setup lang="ts">
-import type { Photo, PhotoPreviewVariant } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
+import type { PhotoPreviewVariant } from '~/types'
 import { getPhotoDownloadFilename, getPhotoDownloadUrl } from '~/utils/photoDownload'
 import PhotoDetailControlButton from './PhotoDetailControlButton.vue'
 
-const props = withDefaults(
-  defineProps<{
-    photo: Photo
-    variant?: PhotoPreviewVariant
-    loading?: boolean
-    progress?: number
-  }>(),
-  {
-    variant: 'origin',
-    loading: false,
-    progress: 0,
-  },
-)
+const { detailPhoto, activePreviewVariant, downloadLoading, downloadProgress } =
+  usePhotoDetailContext()
+const photo = computed(() => detailPhoto.value)
 
-const mediaLabel = computed(() => (props.photo.mediaType === 'video' ? 'video' : 'image'))
+const mediaLabel = computed(() => (photo.value?.mediaType === 'video' ? 'video' : 'image'))
 const downloadVariant = computed<PhotoPreviewVariant>(() =>
-  props.photo.mediaType === 'image' ? props.variant : 'origin',
+  photo.value?.mediaType === 'image' ? activePreviewVariant.value : 'origin',
 )
-const isLoading = computed(() => props.loading && downloadVariant.value === 'compressed')
+const isLoading = computed(() => downloadLoading.value && downloadVariant.value === 'compressed')
 const variantLabel = computed(() => {
   if (downloadVariant.value === 'origin') return 'original'
   if (downloadVariant.value === 'blurhash') return 'BlurHash'
@@ -35,12 +26,12 @@ const label = computed(() =>
       : `Download ${variantLabel.value} ${mediaLabel.value}`,
 )
 const href = computed(() =>
-  isLoading.value
+  !photo.value || isLoading.value
     ? undefined
-    : getPhotoDownloadUrl(props.photo.id, downloadVariant.value, props.photo.blurhash),
+    : getPhotoDownloadUrl(photo.value.id, downloadVariant.value, photo.value.blurhash),
 )
 const filename = computed(() =>
-  getPhotoDownloadFilename(props.photo.filename, downloadVariant.value),
+  getPhotoDownloadFilename(photo.value?.filename ?? 'photo', downloadVariant.value),
 )
 </script>
 
@@ -51,6 +42,6 @@ const filename = computed(() =>
     :href="href"
     :download="filename"
     :loading="isLoading"
-    :progress="props.progress"
+    :progress="downloadProgress"
   />
 </template>

--- a/app/components/photos/photo-detail-controls/PhotoDetailReactionControl.vue
+++ b/app/components/photos/photo-detail-controls/PhotoDetailReactionControl.vue
@@ -1,28 +1,12 @@
 <script setup lang="ts">
-import type { Photo, PhotoReactionType } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import PhotoReactions from '../PhotoReactions.vue'
 import PhotoDetailControlButton from './PhotoDetailControlButton.vue'
 
-interface Props {
-  photo: Photo
-  busy?: boolean
-  disabled?: boolean
-  error?: string | null
-}
-
-interface Emits {
-  react: [reaction: PhotoReactionType]
-}
-
-const props = withDefaults(defineProps<Props>(), {
-  busy: false,
-  disabled: false,
-  error: null,
-})
-const emit = defineEmits<Emits>()
+const { detailPhoto, reactionError, reactionSaving, actions } = usePhotoDetailContext()
 const showReactions = shallowRef(false)
 const reactionControl = useTemplateRef<HTMLElement>('reactionControl')
-const mediaLabel = computed(() => (props.photo.mediaType === 'video' ? 'video' : 'photo'))
+const mediaLabel = computed(() => (detailPhoto.value?.mediaType === 'video' ? 'video' : 'photo'))
 const label = computed(() => `React to this ${mediaLabel.value}`)
 
 onClickOutside(reactionControl, () => {
@@ -40,17 +24,17 @@ onKeyStroke('Escape', () => {
       <PhotoReactions
         v-show="showReactions"
         class="photo-detail-reaction-control__popover"
-        :busy="props.busy"
-        :disabled="props.disabled"
-        :error="props.error"
-        @react="emit('react', $event)"
+        :busy="reactionSaving"
+        :disabled="reactionSaving"
+        :error="reactionError"
+        @react="actions.react"
       />
     </Transition>
 
     <PhotoDetailControlButton
       :label="label"
       icon="i-hugeicons:smile"
-      :disabled="props.disabled"
+      :disabled="reactionSaving"
       :expanded="showReactions"
       has-popup="dialog"
       @click="showReactions = !showReactions"

--- a/app/components/photos/photo-detail-controls/PhotoDetailShareControl.vue
+++ b/app/components/photos/photo-detail-controls/PhotoDetailShareControl.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
 import { play } from 'cuelume'
-import type { Photo } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import PhotoDetailControlButton from './PhotoDetailControlButton.vue'
 
-const props = defineProps<{ photo: Photo }>()
+const { detailPhoto } = usePhotoDetailContext()
 const { copy, copied } = useClipboard({ legacy: true })
-const mediaLabel = computed(() => (props.photo.mediaType === 'video' ? 'video' : 'photo'))
+const mediaLabel = computed(() => (detailPhoto.value?.mediaType === 'video' ? 'video' : 'photo'))
 const label = computed(() => `Copy link to this ${mediaLabel.value}`)
 const icon = computed(() =>
   copied.value ? 'i-hugeicons:checkmark-circle-02' : 'i-hugeicons:share-08',
 )
 
 async function sharePhoto() {
-  const path = `/photos?photo=${encodeURIComponent(props.photo.id)}`
+  if (!detailPhoto.value) return
+
+  const path = `/photos?photo=${encodeURIComponent(detailPhoto.value.id)}`
   try {
     await copy(new URL(path, window.location.origin).href)
     play('success', { volume: 0.85 })

--- a/app/components/photos/photo-detail-controls/PhotoDetailZoomControls.vue
+++ b/app/components/photos/photo-detail-controls/PhotoDetailZoomControls.vue
@@ -1,18 +1,8 @@
 <script setup lang="ts">
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import PhotoDetailControlButton from './PhotoDetailControlButton.vue'
 
-interface Props {
-  zoomLabel: string
-}
-
-interface Emits {
-  zoomIn: []
-  zoomOut: []
-  reset: []
-}
-
-const props = defineProps<Props>()
-const emit = defineEmits<Emits>()
+const { zoomLabel, actions } = usePhotoDetailContext()
 </script>
 
 <template>
@@ -20,18 +10,18 @@ const emit = defineEmits<Emits>()
     <PhotoDetailControlButton
       label="Zoom out"
       icon="i-hugeicons:zoom-out-area"
-      @click="emit('zoomOut')"
+      @click="actions.zoomOut"
     />
     <PhotoDetailControlButton
-      :label="`Reset image view, ${props.zoomLabel}`"
-      :text="props.zoomLabel"
+      :label="`Reset image view, ${zoomLabel}`"
+      :text="zoomLabel"
       variant="value"
-      @click="emit('reset')"
+      @click="actions.resetZoom"
     />
     <PhotoDetailControlButton
       label="Zoom in"
       icon="i-hugeicons:zoom-in-area"
-      @click="emit('zoomIn')"
+      @click="actions.zoomIn"
     />
   </div>
 </template>

--- a/app/components/photos/photo-detail-metadata/PhotoDetailMetadata.vue
+++ b/app/components/photos/photo-detail-metadata/PhotoDetailMetadata.vue
@@ -1,29 +1,13 @@
 <script setup lang="ts">
-import type {
-  Photo,
-  PhotoPreviewLoadingState,
-  PhotoPreviewVariant,
-  PhotoReactionCounts,
-} from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 import PhotoDetailCapture from './PhotoDetailCapture.vue'
 import PhotoDetailFile from './PhotoDetailFile.vue'
 import PhotoDetailPalette from './PhotoDetailPalette.vue'
 import PhotoDetailReactions from './PhotoDetailReactions.vue'
 import PhotoPreviewPanel from './PhotoPreviewPanel.vue'
 
-interface Props {
-  photo: Photo
-  reactionCounts: PhotoReactionCounts
-  previewVariant: PhotoPreviewVariant
-  previewLoading: PhotoPreviewLoadingState
-}
-
-interface Emits {
-  previewChange: [variant: PhotoPreviewVariant]
-}
-
-const props = defineProps<Props>()
-const emit = defineEmits<Emits>()
+const { detailPhoto } = usePhotoDetailContext()
+const photo = computed(() => detailPhoto.value!)
 </script>
 
 <template>
@@ -31,16 +15,10 @@ const emit = defineEmits<Emits>()
     class="photo-dialog__details space-y-[clamp(1.5rem,3vh,2.5rem)] max-md:space-y-[1rem]"
     aria-label="Photo details"
   >
-    <PhotoPreviewPanel
-      v-if="props.photo.mediaType === 'image'"
-      :photo="props.photo"
-      :variant="props.previewVariant"
-      :loading="props.previewLoading"
-      @change="emit('previewChange', $event)"
-    />
+    <PhotoPreviewPanel v-if="photo.mediaType === 'image'" />
     <PhotoDetailFile :photo="photo" />
     <PhotoDetailCapture :photo="photo" />
     <PhotoDetailPalette :photo="photo" />
-    <PhotoDetailReactions :reaction-counts="reactionCounts" />
+    <PhotoDetailReactions />
   </aside>
 </template>

--- a/app/components/photos/photo-detail-metadata/PhotoDetailMetadata.vue
+++ b/app/components/photos/photo-detail-metadata/PhotoDetailMetadata.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import type { Photo, PhotoPreviewVariant, PhotoReactionCounts } from '~/types'
+import type {
+  Photo,
+  PhotoPreviewLoadingState,
+  PhotoPreviewVariant,
+  PhotoReactionCounts,
+} from '~/types'
 import PhotoDetailCapture from './PhotoDetailCapture.vue'
 import PhotoDetailFile from './PhotoDetailFile.vue'
 import PhotoDetailPalette from './PhotoDetailPalette.vue'
@@ -10,6 +15,7 @@ interface Props {
   photo: Photo
   reactionCounts: PhotoReactionCounts
   previewVariant: PhotoPreviewVariant
+  previewLoading: PhotoPreviewLoadingState
 }
 
 interface Emits {
@@ -22,13 +28,14 @@ const emit = defineEmits<Emits>()
 
 <template>
   <aside
-    class="photo-dialog__details space-y-[clamp(2rem,4vh,3.5rem)] max-md:space-y-[1.25rem]"
+    class="photo-dialog__details space-y-[clamp(1.5rem,3vh,2.5rem)] max-md:space-y-[1rem]"
     aria-label="Photo details"
   >
     <PhotoPreviewPanel
       v-if="props.photo.mediaType === 'image'"
       :photo="props.photo"
       :variant="props.previewVariant"
+      :loading="props.previewLoading"
       @change="emit('previewChange', $event)"
     />
     <PhotoDetailFile :photo="photo" />

--- a/app/components/photos/photo-detail-metadata/PhotoDetailReactions.vue
+++ b/app/components/photos/photo-detail-metadata/PhotoDetailReactions.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import { PHOTO_REACTIONS } from '#shared/constants/photo-reactions'
-import type { PhotoReactionCounts, PhotoReactionType } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
+import type { PhotoReactionType } from '~/types'
 import PhotoDetailGroup from './PhotoDetailGroup.vue'
-
-interface Props {
-  reactionCounts: PhotoReactionCounts
-}
 
 interface ActiveReaction {
   type: PhotoReactionType
@@ -14,14 +11,14 @@ interface ActiveReaction {
   count: number
 }
 
-const props = defineProps<Props>()
+const { reactionCounts } = usePhotoDetailContext()
 
 const activeReactions = computed<ActiveReaction[]>(() =>
-  PHOTO_REACTIONS.filter((reaction) => props.reactionCounts[reaction.type] > 0).map((reaction) => ({
+  PHOTO_REACTIONS.filter((reaction) => reactionCounts.value[reaction.type] > 0).map((reaction) => ({
     type: reaction.type,
     icon: reaction.icon,
     label: reaction.label,
-    count: props.reactionCounts[reaction.type],
+    count: reactionCounts.value[reaction.type],
   })),
 )
 </script>

--- a/app/components/photos/photo-detail-metadata/PhotoPreviewPanel.vue
+++ b/app/components/photos/photo-detail-metadata/PhotoPreviewPanel.vue
@@ -1,20 +1,12 @@
 <script setup lang="ts">
-import type { Photo, PhotoPreviewLoadingState, PhotoPreviewVariant } from '~/types'
+import type { PhotoPreviewVariant } from '~/types'
+import { usePhotoDetailContext } from '~/composables/usePhotoDetailContext'
 
-interface Props {
-  photo: Photo
-  variant: PhotoPreviewVariant
-  loading: PhotoPreviewLoadingState
-}
-
-interface Emits {
-  change: [variant: PhotoPreviewVariant]
-}
-
-const props = defineProps<Props>()
-const emit = defineEmits<Emits>()
+const { detailPhoto, previewVariant, previewLoading, actions } = usePhotoDetailContext()
 const hoveredVariant = shallowRef<PhotoPreviewVariant | null>(null)
-const isOriginDisabled = computed(() => props.loading.thumbnail || props.loading.compressed)
+const isOriginDisabled = computed(
+  () => previewLoading.value.thumbnail || previewLoading.value.compressed,
+)
 
 const photoPreviewVariants: readonly PhotoPreviewVariant[] = [
   'thumbnail',
@@ -33,9 +25,9 @@ const previewIcons: Record<PhotoPreviewVariant, string> = {
 const variantDetails = computed<
   Record<PhotoPreviewVariant, { label: string; description: string }>
 >(() => ({
-  thumbnail: { label: 'Thumbnail', description: props.photo.thumbnailSizeFormatted },
-  compressed: { label: 'Compress', description: props.photo.compressedSizeFormatted },
-  origin: { label: 'Original', description: props.photo.originSizeFormatted },
+  thumbnail: { label: 'Thumbnail', description: detailPhoto.value?.thumbnailSizeFormatted ?? '—' },
+  compressed: { label: 'Compress', description: detailPhoto.value?.compressedSizeFormatted ?? '—' },
+  origin: { label: 'Original', description: detailPhoto.value?.originSizeFormatted ?? '—' },
   blurhash: { label: 'BlurHash', description: 'Encoded' },
 }))
 
@@ -58,7 +50,7 @@ function clearHoveredVariant() {
 
 <template>
   <section
-    v-if="photo.mediaType === 'image'"
+    v-if="detailPhoto?.mediaType === 'image'"
     class="photo-preview-panel"
     aria-labelledby="preview-title"
   >
@@ -73,14 +65,14 @@ function clearHoveredVariant() {
         type="button"
         class="photo-preview-panel__option"
         :class="{
-          'is-active': item === variant,
+          'is-active': item === previewVariant,
           'is-hovered': item === hoveredVariant,
         }"
         :disabled="item === 'origin' && isOriginDisabled"
-        :aria-pressed="item === variant"
+        :aria-pressed="item === previewVariant"
         data-cuelume-hover="tick"
         data-cuelume-toggle="toggle"
-        @click="emit('change', item)"
+        @click="actions.setPreviewVariant(item)"
         @mouseenter="setHoveredVariant(item)"
         @mouseleave="clearHoveredVariant"
       >
@@ -90,7 +82,7 @@ function clearHoveredVariant() {
             <span class="photo-preview-panel__option-label">{{ previewLabel(item) }}</span>
             <span class="photo-preview-panel__option-description">
               <i
-                v-if="loading[item]"
+                v-if="previewLoading[item]"
                 class="i-hugeicons:loading-03 animate-pulse animate-spin"
                 aria-hidden="true"
               />

--- a/app/components/photos/photo-detail-metadata/PhotoPreviewPanel.vue
+++ b/app/components/photos/photo-detail-metadata/PhotoPreviewPanel.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import type { Photo, PhotoPreviewVariant } from '~/types'
+import type { Photo, PhotoPreviewLoadingState, PhotoPreviewVariant } from '~/types'
 
 interface Props {
   photo: Photo
   variant: PhotoPreviewVariant
+  loading: PhotoPreviewLoadingState
 }
 
 interface Emits {
@@ -13,6 +14,7 @@ interface Emits {
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 const hoveredVariant = shallowRef<PhotoPreviewVariant | null>(null)
+const isOriginDisabled = computed(() => props.loading.thumbnail || props.loading.compressed)
 
 const photoPreviewVariants: readonly PhotoPreviewVariant[] = [
   'thumbnail',
@@ -74,6 +76,7 @@ function clearHoveredVariant() {
           'is-active': item === variant,
           'is-hovered': item === hoveredVariant,
         }"
+        :disabled="item === 'origin' && isOriginDisabled"
         :aria-pressed="item === variant"
         data-cuelume-hover="tick"
         data-cuelume-toggle="toggle"
@@ -86,7 +89,12 @@ function clearHoveredVariant() {
           <span class="photo-preview-panel__option-copy">
             <span class="photo-preview-panel__option-label">{{ previewLabel(item) }}</span>
             <span class="photo-preview-panel__option-description">
-              {{ previewDescription(item) }}
+              <i
+                v-if="loading[item]"
+                class="i-hugeicons:loading-03 animate-pulse animate-spin"
+                aria-hidden="true"
+              />
+              <template v-else>{{ previewDescription(item) }}</template>
             </span>
           </span>
         </span>
@@ -96,11 +104,6 @@ function clearHoveredVariant() {
 </template>
 
 <style scoped>
-.photo-preview-panel {
-  padding-bottom: clamp(1.5rem, 3vh, 2.25rem);
-  border-bottom: 1px dashed var(--dialog-line);
-}
-
 .photo-preview-panel__heading {
   display: flex;
   align-items: baseline;
@@ -142,6 +145,11 @@ function clearHoveredVariant() {
     border-color 180ms ease,
     background-color 180ms ease,
     color 180ms ease;
+}
+
+.photo-preview-panel__option:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
 }
 
 .photo-preview-panel__option-main {
@@ -260,12 +268,12 @@ function clearHoveredVariant() {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .photo-preview-panel__option:hover {
+  .photo-preview-panel__option:not(:disabled):hover {
     border-color: var(--dialog-line);
     color: var(--dialog-text);
   }
 
-  .photo-preview-panel__option.is-active:hover {
+  .photo-preview-panel__option.is-active:not(:disabled):hover {
     border-color: transparent;
   }
 }

--- a/app/composables/usePhotoDetailContext.ts
+++ b/app/composables/usePhotoDetailContext.ts
@@ -1,0 +1,210 @@
+import { computed, inject, provide, readonly, shallowRef, watch } from 'vue'
+import type { ComputedRef, InjectionKey, MaybeRefOrGetter, ShallowRef } from 'vue'
+import type {
+  Photo,
+  PhotoPreviewLoadingState,
+  PhotoPreviewVariant,
+  PhotoReactionCounts,
+  PhotoReactionType,
+} from '~/types'
+
+export interface CanvasControls {
+  zoomIn: () => void
+  zoomOut: () => void
+  reset: () => void
+}
+
+export interface PhotoDetailContext {
+  photo: ComputedRef<Photo | null>
+  photos: ComputedRef<readonly Photo[]>
+  visible: ComputedRef<boolean>
+  displayedPhoto: Readonly<ShallowRef<Photo | null>>
+  detailPhoto: ComputedRef<Photo | null>
+  currentIndex: ComputedRef<number>
+  hasPrev: ComputedRef<boolean>
+  hasNext: ComputedRef<boolean>
+  isVideo: ComputedRef<boolean>
+  previewVariant: Readonly<ShallowRef<PhotoPreviewVariant>>
+  activePreviewVariant: Readonly<ShallowRef<PhotoPreviewVariant>>
+  checkerboard: Readonly<ShallowRef<boolean>>
+  zoomLabel: Readonly<ShallowRef<string>>
+  downloadLoading: Readonly<ShallowRef<boolean>>
+  downloadProgress: Readonly<ShallowRef<number>>
+  previewLoading: Readonly<ShallowRef<PhotoPreviewLoadingState>>
+  reactionCounts: Readonly<ShallowRef<PhotoReactionCounts>>
+  reactionSaving: Readonly<ShallowRef<boolean>>
+  reactionError: Readonly<ShallowRef<string | null>>
+  actions: PhotoDetailContextActions
+}
+
+export interface PhotoDetailContextActions {
+  close: () => void
+  previous: () => void
+  next: () => void
+  select: (photo: Photo) => void
+  react: (reaction: PhotoReactionType) => void
+  setDisplayedPhoto: (photo: Photo | null) => void
+  setPreviewVariant: (variant: PhotoPreviewVariant) => void
+  setActivePreviewVariant: (variant: PhotoPreviewVariant) => void
+  setCheckerboard: (value: boolean) => void
+  setZoomLabel: (label: string) => void
+  setDownloadProgress: (loading: boolean, progress: number) => void
+  setPreviewLoading: (loading: PhotoPreviewLoadingState) => void
+  registerCanvasControls: (controls: CanvasControls | null) => void
+  zoomIn: () => void
+  zoomOut: () => void
+  resetZoom: () => void
+}
+
+interface PhotoDetailContextOptions {
+  photo: MaybeRefOrGetter<Photo | null>
+  photos: MaybeRefOrGetter<readonly Photo[]>
+  visible: MaybeRefOrGetter<boolean>
+  onClose: () => void
+  onPrevious: () => void
+  onNext: () => void
+  onSelect: (photo: Photo) => void
+}
+
+const photoDetailContextKey: InjectionKey<PhotoDetailContext> = Symbol('photo-detail-context')
+
+export function providePhotoDetailContext(options: PhotoDetailContextOptions): PhotoDetailContext {
+  const photo = computed(() => toValue(options.photo))
+  const photos = computed<readonly Photo[]>(() => toValue(options.photos))
+  const visible = computed(() => toValue(options.visible))
+  const displayedPhoto = shallowRef<Photo | null>(null)
+  const previewVariant = shallowRef<PhotoPreviewVariant>('compressed')
+  const activePreviewVariant = shallowRef<PhotoPreviewVariant>('thumbnail')
+  const checkerboard = shallowRef(false)
+  const zoomLabel = shallowRef('100%')
+  const downloadLoading = shallowRef(false)
+  const downloadProgress = shallowRef(0)
+  const previewLoading = shallowRef<PhotoPreviewLoadingState>(createPreviewLoadingState())
+  const canvasControls = shallowRef<CanvasControls | null>(null)
+  const detailPhoto = computed(() => displayedPhoto.value ?? photo.value)
+  const currentIndex = computed(() => {
+    if (!photo.value) return -1
+    return photos.value.findIndex((item) => item.id === photo.value?.id)
+  })
+  const hasPrev = computed(() => currentIndex.value > 0)
+  const hasNext = computed(
+    () => currentIndex.value >= 0 && currentIndex.value < photos.value.length - 1,
+  )
+  const isVideo = computed(() => detailPhoto.value?.mediaType === 'video')
+  const {
+    counts: reactionCounts,
+    saving: reactionSaving,
+    error: reactionError,
+    react,
+  } = usePhotoReactions(detailPhoto)
+
+  function setPreviewVariant(variant: PhotoPreviewVariant) {
+    if (detailPhoto.value?.mediaType !== 'image') return
+    previewVariant.value = variant
+  }
+
+  function setDownloadProgress(loading: boolean, progress: number) {
+    downloadLoading.value = loading
+    downloadProgress.value = Math.min(100, Math.max(0, progress))
+  }
+
+  function setPreviewLoading(loading: PhotoPreviewLoadingState) {
+    previewLoading.value = { ...loading }
+  }
+
+  function registerCanvasControls(controls: CanvasControls | null) {
+    canvasControls.value = controls
+  }
+
+  const actions: PhotoDetailContextActions = {
+    close: options.onClose,
+    previous() {
+      if (hasPrev.value) options.onPrevious()
+    },
+    next() {
+      if (hasNext.value) options.onNext()
+    },
+    select(photoToSelect) {
+      if (photoToSelect.id !== photo.value?.id) options.onSelect(photoToSelect)
+    },
+    react,
+    setDisplayedPhoto(photoToDisplay) {
+      displayedPhoto.value = photoToDisplay
+    },
+    setPreviewVariant,
+    setActivePreviewVariant(variant) {
+      activePreviewVariant.value = variant
+    },
+    setCheckerboard(value) {
+      checkerboard.value = value
+    },
+    setZoomLabel(label) {
+      zoomLabel.value = label
+    },
+    setDownloadProgress,
+    setPreviewLoading,
+    registerCanvasControls,
+    zoomIn() {
+      canvasControls.value?.zoomIn()
+    },
+    zoomOut() {
+      canvasControls.value?.zoomOut()
+    },
+    resetZoom() {
+      canvasControls.value?.reset()
+    },
+  }
+
+  watch(
+    () => photo.value?.id,
+    () => {
+      previewVariant.value = 'compressed'
+      activePreviewVariant.value = 'thumbnail'
+      previewLoading.value = createPreviewLoadingState()
+      downloadLoading.value = false
+      downloadProgress.value = 0
+      zoomLabel.value = '100%'
+    },
+  )
+
+  const context: PhotoDetailContext = {
+    photo,
+    photos,
+    visible,
+    displayedPhoto: readonly(displayedPhoto),
+    detailPhoto,
+    currentIndex,
+    hasPrev,
+    hasNext,
+    isVideo,
+    previewVariant: readonly(previewVariant),
+    activePreviewVariant: readonly(activePreviewVariant),
+    checkerboard: readonly(checkerboard),
+    zoomLabel: readonly(zoomLabel),
+    downloadLoading: readonly(downloadLoading),
+    downloadProgress: readonly(downloadProgress),
+    previewLoading: readonly(previewLoading),
+    reactionCounts,
+    reactionSaving,
+    reactionError,
+    actions,
+  }
+
+  provide(photoDetailContextKey, context)
+  return context
+}
+
+export function usePhotoDetailContext(): PhotoDetailContext {
+  const context = inject(photoDetailContextKey, null)
+  if (!context) throw new Error('usePhotoDetailContext must be used inside PhotoDetail.')
+  return context
+}
+
+function createPreviewLoadingState(): PhotoPreviewLoadingState {
+  return {
+    thumbnail: false,
+    compressed: false,
+    origin: false,
+    blurhash: false,
+  }
+}

--- a/app/composables/usePhotoFilmstripScroll.ts
+++ b/app/composables/usePhotoFilmstripScroll.ts
@@ -1,0 +1,104 @@
+const STORAGE_KEY = 'zyyv:photo-dialog-filmstrip-scroll'
+const MAX_PERSISTED_ENTRIES = 12
+const memoryCache = new Map<string, number>()
+const pendingCache = new Map<string, number>()
+
+let persistTimer: ReturnType<typeof setTimeout> | undefined
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readPersistedCache(): Record<string, number> {
+  if (!import.meta.client) return {}
+
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecord(parsed)) return {}
+
+    const entries: Record<string, number> = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+        entries[key] = value
+      }
+    }
+    return entries
+  } catch {
+    return {}
+  }
+}
+
+function persistCache() {
+  if (!import.meta.client || !pendingCache.size) return
+
+  const entries = readPersistedCache()
+  for (const [key, value] of pendingCache) entries[key] = value
+
+  const limitedEntries = Object.fromEntries(Object.entries(entries).slice(-MAX_PERSISTED_ENTRIES))
+
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(limitedEntries))
+    pendingCache.clear()
+  } catch {
+    // Memory cache remains available when storage is blocked or full.
+  }
+}
+
+function schedulePersistence() {
+  if (persistTimer) clearTimeout(persistTimer)
+  persistTimer = setTimeout(() => {
+    persistTimer = undefined
+    persistCache()
+  }, 120)
+}
+
+export function getPhotoFilmstripCacheKey(photoIds: readonly string[]): string {
+  let hash = 2166136261
+
+  for (const photoId of photoIds) {
+    for (let index = 0; index < photoId.length; index += 1) {
+      hash = Math.imul(hash ^ photoId.charCodeAt(index), 16777619)
+    }
+    hash = Math.imul(hash ^ 124, 16777619)
+  }
+
+  return `${photoIds.length}:${(hash >>> 0).toString(36)}`
+}
+
+export function usePhotoFilmstripScroll() {
+  function read(key: string): number | null {
+    const memoryValue = memoryCache.get(key)
+    if (memoryValue !== undefined) return memoryValue
+
+    const persistedValue = readPersistedCache()[key]
+    if (persistedValue === undefined) return null
+
+    memoryCache.set(key, persistedValue)
+    return persistedValue
+  }
+
+  function save(key: string, scrollLeft: number) {
+    if (!import.meta.client || !Number.isFinite(scrollLeft)) return
+
+    const value = Math.max(0, Math.round(scrollLeft))
+    memoryCache.set(key, value)
+    pendingCache.set(key, value)
+    schedulePersistence()
+  }
+
+  function flush(key: string) {
+    if (persistTimer) {
+      clearTimeout(persistTimer)
+      persistTimer = undefined
+    }
+
+    const memoryValue = memoryCache.get(key)
+    if (memoryValue !== undefined) pendingCache.set(key, memoryValue)
+    persistCache()
+  }
+
+  return { read, save, flush }
+}

--- a/app/composables/usePhotoImageLoadState.ts
+++ b/app/composables/usePhotoImageLoadState.ts
@@ -1,0 +1,154 @@
+import { computed, inject, provide, shallowRef, toRef, toValue } from 'vue'
+import type { InjectionKey, MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
+import { isImagePreloaded, preloadImage, type ImageLoadProgress } from '~/utils/preloadImage'
+
+export type PhotoImageLoadStatus = 'idle' | 'loading' | 'loaded' | 'error'
+
+export interface PhotoImageLoadRecord {
+  status: PhotoImageLoadStatus
+  progress: ImageLoadProgress
+}
+
+export interface PhotoImagePreloadOptions {
+  expectedBytes?: number
+  onProgress?: (progress: ImageLoadProgress) => void
+}
+
+export interface PhotoImageLoadState {
+  recordFor(source: string): Readonly<Ref<PhotoImageLoadRecord>>
+  isLoaded(source: string): boolean
+  markLoaded(source: string): void
+  markError(source: string): void
+  preload(source: string, options?: PhotoImagePreloadOptions): Promise<boolean>
+}
+
+const photoImageLoadStateKey: InjectionKey<PhotoImageLoadState> = Symbol('photo-image-load-state')
+
+const EMPTY_PROGRESS: ImageLoadProgress = {
+  loadedBytes: 0,
+  totalBytes: 0,
+  percentage: 0,
+}
+
+function createPhotoImageLoadState(): PhotoImageLoadState {
+  const records = new Map<string, ShallowRef<PhotoImageLoadRecord>>()
+  const pendingLoads = new Map<string, Promise<boolean>>()
+
+  function recordFor(source: string) {
+    let record = records.get(source)
+    if (!record) {
+      record = shallowRef({
+        status: source && isImagePreloaded(source) ? 'loaded' : 'idle',
+        progress: EMPTY_PROGRESS,
+      })
+      records.set(source, record)
+    }
+    return record
+  }
+
+  function updateRecord(
+    source: string,
+    status: PhotoImageLoadStatus,
+    progress?: ImageLoadProgress,
+  ) {
+    if (!source) return
+
+    const record = recordFor(source)
+    record.value = {
+      status,
+      progress: progress ?? record.value.progress,
+    }
+  }
+
+  function markLoaded(source: string) {
+    if (!source) return
+    updateRecord(source, 'loaded', {
+      loadedBytes: 0,
+      totalBytes: 0,
+      percentage: 100,
+    })
+  }
+
+  function markError(source: string) {
+    if (!source || isLoaded(source)) return
+    updateRecord(source, 'error')
+  }
+
+  function isLoaded(source: string) {
+    return Boolean(source && recordFor(source).value.status === 'loaded')
+  }
+
+  function preload(source: string, options: PhotoImagePreloadOptions = {}) {
+    if (!source) return Promise.resolve(false)
+    if (isLoaded(source)) {
+      options.onProgress?.(recordFor(source).value.progress)
+      return Promise.resolve(true)
+    }
+
+    const pending = pendingLoads.get(source)
+    if (pending) return pending
+
+    updateRecord(source, 'loading')
+    const request = preloadImage(source, {
+      expectedBytes: options.expectedBytes,
+      onProgress(progress) {
+        updateRecord(source, 'loading', progress)
+        options.onProgress?.(progress)
+      },
+    }).then((loaded) => {
+      // A native <img> may finish before the preload request. Treat that as
+      // success so a slower duplicate request cannot regress the shared state.
+      if (loaded || isLoaded(source)) markLoaded(source)
+      else updateRecord(source, 'error')
+      return loaded || isLoaded(source)
+    })
+
+    pendingLoads.set(source, request)
+    void request.finally(() => {
+      if (pendingLoads.get(source) === request) pendingLoads.delete(source)
+    })
+    return request
+  }
+
+  return { recordFor, isLoaded, markLoaded, markError, preload }
+}
+
+export function providePhotoImageLoadState() {
+  const state = createPhotoImageLoadState()
+  provide(photoImageLoadStateKey, state)
+  return state
+}
+
+export function usePhotoImageLoadState() {
+  return inject(photoImageLoadStateKey, null) ?? createPhotoImageLoadState()
+}
+
+export function usePhotoImage(source: MaybeRefOrGetter<string>) {
+  const sourceRef = toRef(source)
+  const state = usePhotoImageLoadState()
+  const record = computed(() => state.recordFor(toValue(sourceRef)).value)
+  const status = computed(() => record.value.status)
+
+  function markLoaded() {
+    state.markLoaded(toValue(sourceRef))
+  }
+
+  function markError() {
+    state.markError(toValue(sourceRef))
+  }
+
+  function preload(options?: PhotoImagePreloadOptions) {
+    return state.preload(toValue(sourceRef), options)
+  }
+
+  return {
+    record,
+    status,
+    isLoaded: computed(() => status.value === 'loaded'),
+    isLoading: computed(() => status.value === 'loading'),
+    hasError: computed(() => status.value === 'error'),
+    markLoaded,
+    markError,
+    preload,
+  }
+}

--- a/app/composables/usePhotos.ts
+++ b/app/composables/usePhotos.ts
@@ -1,4 +1,7 @@
 import type { Photo, PhotoListResponse } from '~/types'
+import type { MaybeRefOrGetter } from 'vue'
+
+const PHOTO_PAGE_SIZE = 24
 
 interface PhotosPayload {
   photos: Photo[]
@@ -40,7 +43,7 @@ export function usePublicPhotos(options: PublicPhotosOptions = {}) {
   })
 }
 
-function createPhotosPayload(photos: Photo[], page: number, limit: number): PhotosPayload {
+function createPhotosPayload(photos: readonly Photo[], page: number, limit: number): PhotosPayload {
   const offset = (page - 1) * limit
   const total = photos.length
   const totalPages = Math.ceil(total / limit)
@@ -60,18 +63,15 @@ function createPhotosPayload(photos: Photo[], page: number, limit: number): Phot
   }
 }
 
-export function usePhotos(initialPhotos: Photo[] = []) {
-  // 加载状态
-  const loading = ref(false)
-  const currentPage = ref(1)
-  const pageSize = ref(24)
-  const allPhotos = shallowRef<Photo[]>(initialPhotos.slice(0, pageSize.value)) // 存储所有已加载的照片
-  const sourcePhotos = shallowRef<Photo[]>(initialPhotos)
-  const hasMore = ref(initialPhotos.length > pageSize.value) // 是否还有更多数据
-  const error = ref<string | null>(null) // 错误状态
+export function usePhotos(initialPhotos: MaybeRefOrGetter<readonly Photo[]> = []) {
+  const loading = shallowRef(false)
+  const currentPage = shallowRef(1)
+  const allPhotos = shallowRef<Photo[]>([])
+  const sourcePhotos = computed(() => toValue(initialPhotos))
+  const error = shallowRef<string | null>(null)
 
   async function getPhotosPayload(page: number): Promise<PhotosPayload> {
-    return createPhotosPayload(sourcePhotos.value, page, pageSize.value)
+    return createPhotosPayload(sourcePhotos.value, page, PHOTO_PAGE_SIZE)
   }
 
   // 加载照片数据
@@ -93,7 +93,7 @@ export function usePhotos(initialPhotos: Photo[] = []) {
           allPhotos.value = response.photos
         }
 
-        hasMore.value = response.pagination?.hasNext || false
+        currentPage.value = page
       }
     } catch (err: any) {
       console.error('Failed to load photos:', err)
@@ -116,8 +116,7 @@ export function usePhotos(initialPhotos: Photo[] = []) {
       return
     }
 
-    currentPage.value++
-    await loadPhotos(currentPage.value, true)
+    await loadPhotos(currentPage.value + 1, true)
   }
 
   // 监听滚动事件
@@ -150,8 +149,13 @@ export function usePhotos(initialPhotos: Photo[] = []) {
   function resetPhotos() {
     allPhotos.value = []
     currentPage.value = 1
-    hasMore.value = sourcePhotos.value.length ? sourcePhotos.value.length > pageSize.value : true
     loading.value = false
+  }
+
+  function syncPhotos(photos: readonly Photo[]) {
+    allPhotos.value = photos.slice(0, PHOTO_PAGE_SIZE)
+    currentPage.value = 1
+    error.value = null
   }
 
   // 初始加载
@@ -165,8 +169,11 @@ export function usePhotos(initialPhotos: Photo[] = []) {
     await loadPhotos(1)
   }
 
+  watch(sourcePhotos, syncPhotos, { immediate: true })
+
   // 获取照片总数
-  const totalPhotos = computed(() => allPhotos.value.length)
+  const hasMore = computed(() => allPhotos.value.length < sourcePhotos.value.length)
+  const totalPhotos = computed(() => sourcePhotos.value.length)
 
   // 检查是否为空状态
   const isEmpty = computed(() => !loading.value && allPhotos.value.length === 0)

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -75,6 +75,8 @@ export interface PhotoLocationDisplay {
 
 export type PhotoPreviewVariant = 'thumbnail' | 'compressed' | 'origin' | 'blurhash'
 
+export type PhotoPreviewLoadingState = Record<PhotoPreviewVariant, boolean>
+
 export interface Photo {
   id: string
   filename: string

--- a/app/utils/photoDownload.ts
+++ b/app/utils/photoDownload.ts
@@ -1,0 +1,27 @@
+import type { PhotoPreviewVariant } from '~/types'
+
+export function getPhotoDownloadFilename(filename: string, variant: PhotoPreviewVariant): string {
+  if (variant === 'origin') return filename
+
+  const extensionIndex = filename.lastIndexOf('.')
+  const hasExtension = extensionIndex > 0 && extensionIndex < filename.length - 1
+  const basename = hasExtension ? filename.slice(0, extensionIndex) : filename
+
+  if (variant === 'blurhash') return `${basename}_blurhash.txt`
+
+  const extension = hasExtension ? filename.slice(extensionIndex) : ''
+  return `${basename}_${variant}${extension}`
+}
+
+export function getPhotoDownloadUrl(
+  photoId: string,
+  variant: PhotoPreviewVariant,
+  blurhash?: string,
+): string {
+  const encodedPhotoId = encodeURIComponent(photoId)
+  if (variant === 'blurhash') {
+    return `data:text/plain;charset=utf-8,${encodeURIComponent(blurhash ?? '')}`
+  }
+  if (variant === 'origin') return `/api/photos/${encodedPhotoId}/download`
+  return `/api/photo-assets/${encodedPhotoId}/${variant}`
+}

--- a/app/utils/preloadImage.ts
+++ b/app/utils/preloadImage.ts
@@ -6,7 +6,7 @@ export interface ImageLoadProgress {
   percentage: number
 }
 
-interface PreloadImageOptions {
+export interface PreloadImageOptions {
   expectedBytes?: number
   onProgress?: (progress: ImageLoadProgress) => void
 }

--- a/server/api/photos/[id]/download.get.ts
+++ b/server/api/photos/[id]/download.get.ts
@@ -1,5 +1,22 @@
+import type { PhotoPreviewVariant } from '~/types'
+import { getPhotoDownloadFilename } from '~/utils/photoDownload'
 import { useCloudflareBindings } from '../../../utils/cloudflare'
 import { getPhotoRow } from '../../../utils/photos'
+
+const downloadVariants = new Set<PhotoPreviewVariant>([
+  'origin',
+  'compressed',
+  'thumbnail',
+  'blurhash',
+])
+
+function getDownloadVariant(value: unknown): PhotoPreviewVariant {
+  if (value === undefined) return 'origin'
+  if (typeof value !== 'string' || !downloadVariants.has(value as PhotoPreviewVariant)) {
+    throw createError({ statusCode: 400, statusMessage: '不支持的图片版本' })
+  }
+  return value as PhotoPreviewVariant
+}
 
 export default defineEventHandler(async (event) => {
   const photoId = getRouterParam(event, 'id')
@@ -11,12 +28,32 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: '图片不存在' })
   }
 
-  const object = await PHOTOS.get(photo.origin_key)
-  if (!object) throw createError({ statusCode: 404, statusMessage: 'R2 中未找到图片' })
+  const variant = getDownloadVariant(getQuery(event).variant)
+  const filename = getPhotoDownloadFilename(photo.filename, variant)
+  const fallbackBaseFilename = `photo-${photo.id}${photo.filename.match(/\.[a-z0-9]{1,8}$/iu)?.[0] ?? ''}`
+  const fallbackFilename = getPhotoDownloadFilename(fallbackBaseFilename, variant)
+  const encodedFilename = encodeURIComponent(filename)
 
-  const extension = photo.filename.match(/\.[a-z0-9]{1,8}$/iu)?.[0] ?? ''
-  const fallbackFilename = `photo-${photo.id}${extension}`
-  const encodedFilename = encodeURIComponent(photo.filename)
+  if (variant === 'blurhash') {
+    const blurhash = photo.blurhash
+    setResponseHeaders(event, {
+      'Cache-Control': 'private, no-store',
+      'Content-Disposition': `attachment; filename="${fallbackFilename}"; filename*=UTF-8''${encodedFilename}`,
+      'Content-Length': String(new TextEncoder().encode(blurhash).byteLength),
+      'Content-Type': 'text/plain; charset=utf-8',
+    })
+
+    return blurhash
+  }
+
+  const objectKey =
+    variant === 'compressed'
+      ? photo.compressed_key
+      : variant === 'thumbnail'
+        ? photo.thumbnail_key
+        : photo.origin_key
+  const object = await PHOTOS.get(objectKey)
+  if (!object) throw createError({ statusCode: 404, statusMessage: 'R2 中未找到图片' })
 
   setResponseHeaders(event, {
     'Cache-Control': 'private, no-store',


### PR DESCRIPTION
## Summary
- centralize PhotoDetail state with a typed provide/inject context
- move canvas, filmstrip, controls, metadata, and preview behavior into their own components
- make photo data synchronization and pagination behavior reactive inside usePhotos

## Verification
- nuxt typecheck
- oxlint
- oxfmt check
- git diff --check
- browser smoke test: photo detail, zoom, filmstrip switching, close, and ripplable view